### PR TITLE
Add comprehensive auth decorator to webpay views (bug 821465)

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -14,7 +14,6 @@ TEMPLATE_DEBUG = True
 # be intercepted by mock objects.
 FAKE_PAYMENTS = False
 
-
 # This is the domain that the tests use, setting this removes a warning that
 # persona throws.
 SITE_URL = 'http://testserver'

--- a/webpay/auth/decorators.py
+++ b/webpay/auth/decorators.py
@@ -2,16 +2,99 @@ import functools
 
 import commonware.log
 
+from django import http
 from django.core.exceptions import PermissionDenied
+from django.core.urlresolvers import reverse
+
+from utils import log_cef
+
 
 log = commonware.log.getLogger('w.auth')
 
+flow = {
+    'standard': ['create', 'confirm', 'verify', 'reset_start'],
+    'reset': ['reset_new_pin', 'reset_confirm', 'reset_cancel'],
+}
+
+def log_redirect(request, step, dest):
+    log_cef('Buyer was attempting %s redirecting to: %s' % (step, dest),
+            request)
 
 def user_verified(f):
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
         if not request.session.get('uuid'):
-            log.error('No uuid in session, not verified.')
+            log_cef('No UUID in session, not verified', request)
             raise PermissionDenied
         return f(request, *args, **kw)
     return wrapper
+
+
+def enforce_sequence(func):
+    def wrapper(request, *args, **kw):
+        step = func.func_name
+        if not request.session.get('uuid'):
+            log_cef('No UUID in session, not verified', request)
+            raise PermissionDenied
+        if request.session.get('uuid_needs_pin_reset'):
+            return get_reset_step(request, step) or func(request, *args, **kw)
+        return get_standard_step(request, step) or func(request, *args, **kw)
+    return functools.wraps(func)(wrapper)
+
+
+def get_reset_step(request, step):
+    """Returns the view the buyer should be at or None if they are already
+    there. This is only called if they already have needs_pin_reset flag set.
+
+    :rtype: HttpResponse or None
+    """
+    try:
+        step_index = flow['reset'].index(step)
+    except ValueError:
+        step_index = -1
+
+    # If they have a new pin already, make sure they are headed to confirm or
+    # cancel.
+    if request.session.get('uuid_has_new_pin'):
+        if step_index < flow['reset'].index('reset_confirm'):
+            log_redirect(request, step, 'reset_confirm')
+            return http.HttpResponseRedirect(reverse('pin.reset_confirm'))
+
+    # If they haven't set their new pin yet, make sure they are headed to do
+    # that.
+    elif step_index != flow['reset'].index('reset_new_pin'):
+        log_redirect(request, step, 'reset_new_pin')
+        return http.HttpResponseRedirect(reverse('pin.reset_new_pin'))
+
+
+def get_standard_step(request, step):
+    """Returns the view the buyer should be at or None if they are already
+    there.
+
+    :rtype: HttpResponse or None
+    """
+    try:
+        step_index = flow['standard'].index(step)
+    except ValueError:
+        step_index = -1
+
+    # Check to see if the buyer has confirmed their pin, if they are trying to
+    # hit a step that comes before that, redirect them to verify
+    if request.session.get('uuid_has_confirmed_pin'):
+        # -1 means they are in a different flow
+        if step_index < flow['standard'].index('verify') or step_index == -1:
+            log_redirect(request, step, 'verify')
+            return http.HttpResponseRedirect(reverse('pin.verify'))
+
+    # Buyer hasn't confirmed pin, check that they have a pin, if they are
+    # trying to hit a step that isn't confirming their pin, redirect them.
+    elif request.session.get('uuid_has_pin'):
+        if step_index != flow['standard'].index('confirm'):
+            log_redirect(request, step, 'confirm')
+            return http.HttpResponseRedirect(reverse('pin.confirm'))
+
+    # Buyer has no pin, send them to create if they aren't already headed
+    # there.
+    elif step_index > flow['standard'].index('create'):
+        log_redirect(request, step, 'create')
+        return http.HttpResponseRedirect(reverse('pin.create'))

--- a/webpay/auth/tests/test_decorators.py
+++ b/webpay/auth/tests/test_decorators.py
@@ -64,7 +64,7 @@ class TestBuyerHasResetFlag(SessionTestCase):
             'meta': {'total_count': 0}
         }
         self.do_auth()
-        eq_(self.client.session.get('uuid_reset_pin'), False)
+        eq_(self.client.session.get('uuid_needs_pin_reset'), False)
 
     @mock.patch('lib.solitude.api.client.slumber')
     def test_user_no_reset_pin_flag(self, slumber):
@@ -74,7 +74,7 @@ class TestBuyerHasResetFlag(SessionTestCase):
                          'needs_pin_reset': False}]
         }
         self.do_auth()
-        eq_(self.client.session.get('uuid_reset_pin'), False)
+        eq_(self.client.session.get('uuid_needs_pin_reset'), False)
 
     @mock.patch('lib.solitude.api.client.slumber')
     def test_user_with_reset_pin_flag(self, slumber):
@@ -84,4 +84,4 @@ class TestBuyerHasResetFlag(SessionTestCase):
                          'needs_pin_reset': True}]
         }
         self.do_auth()
-        eq_(self.client.session.get('uuid_reset_pin'), True)
+        eq_(self.client.session.get('uuid_needs_pin_reset'), True)

--- a/webpay/auth/utils.py
+++ b/webpay/auth/utils.py
@@ -1,6 +1,9 @@
+import functools
 import hashlib
 
 from django.conf import settings
+
+from cef import log_cef as _log_cef
 
 from lib.solitude.api import client
 
@@ -34,12 +37,39 @@ def set_user(request, email):
     request.session['uuid'] = uuid
     buyer = client.get_buyer(uuid)
     set_user_has_pin(request, buyer.get('pin', False))
+    set_user_has_confirmed_pin(request, buyer.get('pin_confirmed', False))
     set_user_reset_pin(request, buyer.get('needs_pin_reset', False))
+    set_user_has_new_pin(request, buyer.get('new_pin', False))
 
 
 def set_user_has_pin(request, has_pin):
     request.session['uuid_has_pin'] = has_pin
 
 
+def set_user_has_confirmed_pin(request, has_confirmed_pin):
+    request.session['uuid_has_confirmed_pin'] = has_confirmed_pin
+
+
 def set_user_reset_pin(request, reset_pin):
-    request.session['uuid_reset_pin'] = reset_pin
+    request.session['uuid_needs_pin_reset'] = reset_pin
+
+
+def set_user_has_new_pin(request, has_new_pin):
+    request.session['uuid_has_new_pin'] = has_new_pin
+
+
+def log_cef(msg, request, **kw):
+    g = functools.partial(getattr, settings)
+    severity = kw.get('severity', g('CEF_DEFAULT_SEVERITY', 5))
+    cef_kw = {
+        'msg': msg,
+        'signature': request.get_full_path(),
+        'config': {
+            'cef.product': 'WebPay',
+            'cef.vendor': g('CEF_VENDOR', 'Mozilla'),
+            'cef.version': g('CEF_VERSION', '0'),
+            'cef.device_version': g('CEF_DEVICE_VERSION', '0'),
+            'cef.file': g('CEF_FILE', 'syslog'),
+        },
+    }
+    _log_cef(msg, severity, request.META.copy(), **cef_kw)

--- a/webpay/pin/views.py
+++ b/webpay/pin/views.py
@@ -8,7 +8,7 @@ import commonware.log
 
 from lib.solitude.api import client
 from tower import ugettext as _
-from webpay.auth.decorators import user_verified
+from webpay.auth.decorators import enforce_sequence
 from webpay.auth.utils import get_user, set_user_has_pin
 from webpay.pay import get_payment_url
 from . import forms
@@ -17,7 +17,7 @@ from . import utils
 log = commonware.log.getLogger('w.pin')
 
 
-@user_verified
+@enforce_sequence
 def create(request):
     form = forms.CreatePinForm()
     if request.method == 'POST':
@@ -35,7 +35,7 @@ def create(request):
                   'action': reverse('pin.create') })
 
 
-@user_verified
+@enforce_sequence
 def confirm(request):
     form = forms.ConfirmPinForm()
     if request.method == 'POST':
@@ -47,7 +47,7 @@ def confirm(request):
                   'action': reverse('pin.confirm') })
 
 
-@user_verified
+@enforce_sequence
 def verify(request):
     form = forms.VerifyPinForm()
     # pin_recently_entered is on the form because the template expect it as it
@@ -67,14 +67,14 @@ def verify(request):
                   'action': reverse('pin.verify') })
 
 
-@user_verified
+@enforce_sequence
 def reset_start(request):
     # TODO(Wraithan): Create dialog to make sure you meant to reset your pin
     client.set_needs_pin_reset(get_user(request))
     return http.HttpResponseRedirect(reverse('auth.logout'))
 
 
-@user_verified
+@enforce_sequence
 def reset_new_pin(request):
     form = forms.CreatePinForm()
     if request.method == 'POST':
@@ -89,7 +89,7 @@ def reset_new_pin(request):
                   'action': reverse('pin.reset_new_pin') })
 
 
-@user_verified
+@enforce_sequence
 def reset_confirm(request):
     form = forms.ConfirmPinForm()
     if request.method == 'POST':
@@ -105,7 +105,7 @@ def reset_confirm(request):
                   'action': reverse('pin.reset_confirm') })
 
 
-@user_verified
+@enforce_sequence
 def reset_cancel(request):
     client.set_needs_pin_reset(get_user(request), False)
     return http.HttpResponseRedirect(reverse('pin.verify'))


### PR DESCRIPTION
Setting this up to track work/progress/get code reviews as needed.
