### PR TITLE
clear new_pin when starting reset flow (bug 834776)

### DIFF
--- a/lib/solitude/api.py
+++ b/lib/solitude/api.py
@@ -69,7 +69,8 @@ class SolitudeAPI(SlumberWrapper):
         """
         buyer = self.get_buyer(uuid)
         res = self.safe_run(self.slumber.generic.buyer(id=buyer['id']).patch,
-                            {'needs_pin_reset': value})
+                            {'needs_pin_reset': value,
+                             'new_pin': None})
         if 'errors' in res:
             return res
         return {}

--- a/lib/solitude/tests.py
+++ b/lib/solitude/tests.py
@@ -99,16 +99,20 @@ class SolitudeAPITest(TestCase):
 
     def test_reset_pin_flag_set(self):
         # set
+        client.set_new_pin(self.uuid, '1234')
         res = client.set_needs_pin_reset(self.uuid)
         eq_(res, {})
         buyer = client.get_buyer(self.uuid)
         assert buyer['needs_pin_reset']
+        assert not buyer['new_pin']
 
         # unset
+        client.set_new_pin(self.uuid, '1234')
         res = client.set_needs_pin_reset(self.uuid, False)
         eq_(res, {})
         buyer = client.get_buyer(self.uuid)
         assert not buyer['needs_pin_reset']
+        assert not buyer['new_pin']
 
     def test_set_new_pin_for_reset(self):
         uuid = 'set_new_pin_for_reset'


### PR DESCRIPTION
The problem was if you had a new_pin you'd be put in the confirm your new pin flow. Fixed that, found [bug 835833](https://bugzil.la/835833) will have a PR for that shortly.
