### PR TITLE
lobby unsets reset flag if possible (bug 837926) 

### DIFF
--- a/webpay/pay/tests/test_views.py
+++ b/webpay/pay/tests/test_views.py
@@ -103,6 +103,19 @@ class TestVerify(Base):
         assert res['Location'].endswith(get_payment_url())
 
     @mock.patch('lib.solitude.api.SolitudeAPI.get_secret')
+    @mock.patch('lib.marketplace.api.MarketplaceAPI.get_price')
+    @mock.patch('lib.solitude.api.SolitudeAPI.set_needs_pin_reset')
+    def test_reset_flag_true(self, set_needs_pin_reset, get_price, get_secret):
+        get_secret.return_value = self.secret
+        self.session['uuid_needs_pin_reset'] = True
+        self.session['uuid'] = 'some:uuid'
+        self.session.save()
+        payload = self.request(iss=self.key, app_secret=self.secret)
+        res = self.get(payload)
+        eq_(res.status_code, 200)
+        assert set_needs_pin_reset.called
+
+    @mock.patch('lib.solitude.api.SolitudeAPI.get_secret')
     def test_inapp_wrong_secret(self, get_secret):
         get_secret.return_value = self.secret
         payload = self.request(iss=self.key, app_secret=self.secret + '.nope')

--- a/webpay/pay/views.py
+++ b/webpay/pay/views.py
@@ -103,6 +103,13 @@ def lobby(request):
     if pin_recently_entered(request):
         return http.HttpResponseRedirect(get_payment_url())
 
+    # If the buyer closed the trusted UI during reset flow, we want to unset
+    # the reset pin flag. They can hit the forgot pin button if they still
+    # don't remember their pin.
+    if request.session.get('uuid_needs_pin_reset'):
+        solitude.set_needs_pin_reset(request.session['uuid'], False)
+        request.session['uuid_needs_pin_reset'] = False
+
     return render(request, 'pay/lobby.html', {
         'action': reverse('pin.verify'),
         'form': pin_form,


### PR DESCRIPTION
Decision was to unset the reset flag instead of trying to redirect them back into the proper place in the flow if they hit the lobby since they are starting a new payment at that point.
