### PR TITLE
Remove redraw toggle

### DIFF
--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -62,8 +62,6 @@ require(['cli'], function(cli) {
         } else if (newLen === (binLength -1)) {
             $('button[type="submit"]').prop('disabled', true);
         }
-
-        $('.button').toggleClass('redraw');
     }
 
     $(window).on('focus', '.pinbox input', function(e) {


### PR DESCRIPTION
Remove redraw class toggle accidentally left in whilst looking into https://bugzilla.mozilla.org/show_bug.cgi?id=840117
