### PR TITLE
Update css conf so relative img urls work consistently (bug 861405)

### DIFF
--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -8,7 +8,7 @@
     <title>{% block page_title %}{{ _('Web Pay') }}{% endblock %}</title>
 
     {% block site_css %}
-      {{ css('pay') }}
+      {{ css('pay/pay') }}
     {% endblock %}
 
     {% block extra_head %}

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -32,7 +32,7 @@ MEDIA_URL = '/mozpay/media/'
 # A list of our CSS and JS assets for jingo-minify.
 MINIFY_BUNDLES = {
     'css': {
-        'pay': (
+        'pay/pay': (
             'css/pay/pay.less',
         ),
     },
@@ -62,6 +62,9 @@ CSS_MEDIA_DEFAULT = 'all'
 
 # Tell jingo-minify to use the media URL instead.
 JINGO_MINIFY_USE_STATIC = False
+
+# Cache-bust images in the CSS.
+CACHEBUST_IMGS = True
 
 # LESS CSS OPTIONS (Debug only)
 LESS_PREPROCESS = False  # Compile LESS with Node, rather than client-side JS?


### PR DESCRIPTION
This branch changes CSS to be built in the same dir as the source so that relative urls are consistent between local and dev etc as the discrepancy currently causes images reference from the css to 404 in -dev.

This also enables the cache-busting setting for jingo-minify.
