### PR TITLE
Improve forgot pin link spacing (bug 862277)

### DIFF
--- a/media/css/pay/pay.less
+++ b/media/css/pay/pay.less
@@ -102,14 +102,14 @@ form footer button[type=submit] {
 
 /* PIN Entry Box */
 .pinbox {
-    padding-top: 10px;
+    padding-top: 5px;
     position: relative;
     width: 100%;
     input {
         background: transparent;
         border: 0;
         display: block;
-        font-size: 3em;
+        font-size: 2.5em;
         opacity: 0;
         position: absolute;
         text-align: center;
@@ -172,9 +172,10 @@ form footer button[type=submit] {
 }
 
 .forgot-pin {
+    float: left;
+    padding: 5px 0;
     position: relative;
     z-index: 10;
-    margin: 5px 0;
 }
 
 .error .forgot-pin {

--- a/media/js/pay/pay.js
+++ b/media/js/pay/pay.js
@@ -92,6 +92,7 @@ require(['cli', 'pay/bango'], function(cli, bango) {
     $('#forgot-pin').click(function(evt) {
         var anchor = $(this);
         var bangoReq;
+        evt.stopPropagation();
         evt.preventDefault();
         // Temporary logging for bug 850899
         console.log('Calling bango.logout() from', anchor.attr('id'), anchor.attr('class'));


### PR DESCRIPTION
This branch adds a bit more space around the "forgot your pin" link and also prevents the bubbling so when clicked the pin input isn't focused.
