### PR TITLE
Update error messages (bug 863493)

### DIFF
--- a/media/css/pay/pay.less
+++ b/media/css/pay/pay.less
@@ -188,14 +188,14 @@ form footer button[type=submit] {
     }
 }
 
-p.error {
+.error-msg {
     color: #A50606;
     display: none;
     line-height: 18px;
     margin: 5px 0;
 }
 
-.error p.error {
+.error .error-msg {
     display: block;
     float: left;
 }

--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -1,8 +1,12 @@
 require(['cli'], function(cli) {
-    var interval = false;
+    var $errorMsg = $('.error-msg');
+    var $forgotPin = $('.forgot-pin');
+    var $pinBox = $('.pinbox');
+    var $pinInput = $('.pinbox input');
+    var $submitButton = $('button[type="submit"]');
     var PINLENGTH = 4;
-
     var currentInput = null;
+    var interval = false;
 
     function watchInput(i) {
         stopWatching();
@@ -22,11 +26,14 @@ require(['cli'], function(cli) {
     }
 
     function warn(msg) {
-        $('h2').text(msg);
+        $errorMsg.text(msg);
+        $pinBox.addClass('error');
+        $forgotPin.hide();
+        $submitButton.prop('disabled', true);
     }
 
-    function validate(input) {
-        var value = input.val();
+    function validate() {
+        var value = $pinInput.val();
         if (!value || value.length < 4) {
             warn(cli.bodyData.pinShortWarning);
             return false;
@@ -58,28 +65,31 @@ require(['cli'], function(cli) {
                       .toggleClass('current', i === newLen);
         }
         if (newLen === binLength) {
-            $('button[type="submit"]').prop('disabled', false);
+            $submitButton.prop('disabled', false);
         } else if (newLen === (binLength -1)) {
-            $('button[type="submit"]').prop('disabled', true);
+            $submitButton.prop('disabled', true);
         }
     }
 
     $(window).on('focus', '.pinbox input', function(e) {
         this.value = '';
-        $('.pinbox').removeClass('error');
-        $('button[type="submit"]').prop('disabled', true);
+        $pinBox.removeClass('error');
+        $submitButton.prop('disabled', true);
+        $forgotPin.show();
         watchInput(this);
     }).on('blur', '.pinbox input', function(e) {
         stopWatching();
     }).on('click', '.pinbox', function(e) {
-        $('.pinbox input').focus();
+        $pinInput.focus();
     });
 
-    $('.pinbox').each(function() {
+    $('#pin').on('submit', validate);
+
+    $pinBox.each(function() {
         var $el = $(this);
         var box = $('<div class="display">');
         var hasError = $el.hasClass('error');
-        var pinClass = hasError ? ' class=filled' : '';
+        var pinClass = hasError ? ' class="filled"' : '';
         box.html(Array(PINLENGTH+1).join('<span'+pinClass+'></span>'));
         $el.prepend(box);
         if (!hasError) {

--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -21,8 +21,8 @@
     data-terms-of-service="https://marketplace.firefox.com/terms-of-use"
     data-unverified-issuer="{{ settings.BROWSERID_UNVERIFIED_ISSUER }}"
     data-bango-logout-url="{{ settings.BANGO_LOGOUT_URL }}"
-    data-pin-short-warning="{{ _('PIN must be 4 digits.') }}"
-    data-pin-non-numeric-warning="{{ _('PIN can only contain digits.') }}"
+    data-pin-short-warning="{{ _('Pin must be 4 digits.') }}"
+    data-pin-non-numeric-warning="{{ _('Pin can only contain digits.') }}"
     >
     <section class="pay">
       <div id="content">

--- a/webpay/pin/forms.py
+++ b/webpay/pin/forms.py
@@ -37,6 +37,10 @@ class BasePinForm(forms.Form):
         errors = response.get('errors')
         if errors:
             for field, error in errors.iteritems():
+                # Solitude returns some pin errors under 'new_pin' rather than 'pin'
+                # so we ensure these are associated with the pin field too.
+                if field == 'new_pin':
+                    field = 'pin'
                 if field in self.fields:
                     self.append_to_errors(field, error)
                 else:
@@ -87,7 +91,7 @@ class ConfirmPinForm(BasePinForm):
         if self.handle_client_errors(client.confirm_pin(self.uuid, pin)):
             return pin
 
-        raise forms.ValidationError(_("PIN doesn't match."))
+        raise forms.ValidationError(_("Pins do not match."))
 
 
 class ResetPinForm(BasePinForm):
@@ -109,4 +113,4 @@ class ResetConfirmPinForm(BasePinForm):
         if self.handle_client_errors(client.reset_confirm_pin(self.uuid, pin)):
             return pin
 
-        raise forms.ValidationError(_("PIN doesn't match."))
+        raise forms.ValidationError(_("Pins do not match."))

--- a/webpay/pin/templates/pin/pin_form.html
+++ b/webpay/pin/templates/pin/pin_form.html
@@ -23,9 +23,7 @@
       {% if not form.pin_is_locked %}
         <div class="pinbox{% if form.pin.errors %} error{% endif %}">
           {{ form.pin }}
-          {% if form.pin.errors %}
-          <p class="error">{{ form.pin.errors[0] }}</p>
-          {% endif %}
+          <p class="error-msg">{% if form.pin.errors %}{{ form.pin.errors[0] }}{% endif %}</p>
           {% if not form.no_pin and not form.reset_flow %}
           {# L10n: This is the same as the standard forgot
                    password that most sites have. #}
@@ -57,7 +55,7 @@
         {% if form.pin_is_locked %}
           <a class="button force-auth-button lock-continue" href="#">
             {{ _('Sign in') }}
-          </a> 
+          </a>
         {% else %}
           <button disabled type="submit">{{ _('Continue') }}</button>
         {% endif %}

--- a/webpay/pin/tests/test_forms.py
+++ b/webpay/pin/tests/test_forms.py
@@ -83,7 +83,7 @@ class ConfirmPinFormTest(BasePinFormTestCase):
     def test_incorrect_pin(self):
         form = forms.ConfirmPinForm(uuid=self.uuid, data=self.data)
         assert not form.is_valid()
-        assert "PIN doesn't match." in form.errors['pin']
+        assert "Pins do not match." in form.errors['pin']
 
     def test_too_long_pin(self):
         self.data.update({'pin': 'way too long pin'})
@@ -103,7 +103,7 @@ class ResetConfirmPinFormTest(BasePinFormTestCase):
     def test_incorrect_pin(self):
         form = forms.ResetConfirmPinForm(uuid=self.uuid, data=self.data)
         assert not form.is_valid()
-        assert "PIN doesn't match." in form.errors['pin']
+        assert "Pins do not match." in form.errors['pin']
 
     def test_too_long_pin(self):
         self.data.update({'pin': 'way too long pin'})

--- a/webpay/pin/tests/test_views.py
+++ b/webpay/pin/tests/test_views.py
@@ -252,6 +252,27 @@ class ResetNewPinViewTest(PinViewTestCase):
         eq_(form.errors.get('pin'),
             [ERROR_STRINGS['PIN may only consists of numbers']])
 
+    @patch.object(client, 'get_buyer', lambda x: {'uuid': x, 'id': '1'})
+    @patch.object(client, 'set_new_pin',
+                  lambda x, y: {'errors':
+                                {'new_pin':
+                                 ['PIN must be exactly 4 numbers long']}})
+    def test_short_new_pin(self):
+        res = self.client.post(self.url, data={'pin': '123'})
+        form = res.context['form']
+        eq_(form.errors.get('pin'),
+            [ERROR_STRINGS['PIN must be exactly 4 numbers long']])
+
+    @patch.object(client, 'get_buyer', lambda x: {'uuid': x, 'id': '1'})
+    @patch.object(client, 'set_new_pin',
+                  lambda x, y: {'errors':
+                                {'new_pin': ['PIN may only consists of numbers']}})
+    def test_alpha_new_pin(self):
+        res = self.client.post(self.url, data={'pin': '1234'})
+        form = res.context['form']
+        eq_(form.errors.get('pin'),
+            [ERROR_STRINGS['PIN may only consists of numbers']])
+
 
 class ResetConfirmPinViewTest(PinViewTestCase):
     url_name = 'pin.reset_confirm'


### PR DESCRIPTION
Add client-side validation for pin format.

Solitude was exposing some error messages under "new_pin" rather than "pin" this addresses that too.
