### PR TITLE
Update sign-in copy (bug 863462) (Don't merge just yet)

### DIFF
--- a/media/css/pay/pay.less
+++ b/media/css/pay/pay.less
@@ -267,6 +267,7 @@ a.sign-in,
 .sign-in {
     color: @dark-gray;
     display: block;
+    font-size: 14px;
     height: 42px;
     line-height: 42px;
     margin-top: 20px;

--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -18,8 +18,9 @@
   </head>
   <body
     {% block body_attrs %}{% endblock %}
-    data-privacy-policy="https://marketplace.firefox.com/privacy-policy"
-    data-terms-of-service="https://marketplace.firefox.com/terms-of-use"
+
+    data-privacy-policy="{{ settings.PRIVACY_POLICY_URL }}"
+    data-terms-of-service="{{ settings.TERMS_URL }}"
     data-unverified-issuer="{{ settings.BROWSERID_UNVERIFIED_ISSUER }}"
     data-logged-in-user="{{ session.get('logged_in_user', '') }}"
     data-reset-user-url="{{ url('auth.reset_user') }}"

--- a/webpay/pay/templates/pay/lobby.html
+++ b/webpay/pay/templates/pay/lobby.html
@@ -8,7 +8,12 @@
 {% block extra_content %}
   <div id="login" class="message hidden">
     <h2>{{ _('Sign In') }}</h2>
-    <p>{{ _('Sign in to continue with the payment') }}</p>
     <a id="signin" class="sign-in" href="#">{{ _('Sign in') }}</a>
+    <p>
+    {%- trans terms_url=settings.TERMS_URL,
+              privacy_policy_url=settings.PRIVACY_POLICY_URL %}
+    By proceeding, you agree to Persona's <a href="{{ terms_url }}" target="_blank">Terms</a> and <a href="{{ privacy_policy_url }}" target="_blank">Privacy Policy</a>.
+    {% endtrans -%}
+    </p>
   </div>
 {% endblock %}

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -306,3 +306,7 @@ TEST_PIN_UI = False
 # If True, only simulated payments can be processed. All other requests will
 # result in an error.
 ONLY_SIMULATIONS = False
+
+# Terms and privacy policy urls.
+PRIVACY_POLICY_URL = 'https://marketplace.firefox.com/privacy-policy'
+TERMS_URL = 'https://marketplace.firefox.com/terms-of-use'


### PR DESCRIPTION
Update the sign-in page copy to match the mock.

Let me know if there's a better way to handle the links in the translation string.
