### PR TITLE
make api the api/v1 endpoint instead of slumber and use that (bug 864507...

### DIFF
--- a/lib/marketplace/api.py
+++ b/lib/marketplace/api.py
@@ -14,8 +14,7 @@ class MarketplaceAPI(SlumberWrapper):
     def get_price(self, tier):
         # TODO: cache this.
         try:
-            return (self.slumber.api.webpay.prices(id=tier)
-                        .get(provider='bango'))
+            return self.api.webpay.prices(id=tier).get(provider='bango')
         except HttpClientError, err:
             if err.response.status_code:
                 raise TierNotFound(tier)

--- a/lib/marketplace/tests.py
+++ b/lib/marketplace/tests.py
@@ -10,15 +10,15 @@ sample_price = {
     u'name': u'Tier 0',
     u'prices': [{u'amount': u'1.00', u'currency': u'USD'},
                 {u'amount': u'3.00', u'currency': u'JPY'}],
-    u'resource_uri': u'/api/webpay/prices/1/'
+    u'resource_uri': u'/api/v1/webpay/prices/1/'
 }
 
-@mock.patch('lib.marketplace.api.client.slumber')
+@mock.patch('lib.marketplace.api.client.api')
 class SolitudeAPITest(TestCase):
 
     def test_get_prices(self, slumber):
         sample = mock.Mock()
         sample.get.return_value = sample_price
-        slumber.api.webpay.prices.return_value = sample
+        slumber.webpay.prices.return_value = sample
         prices = client.get_price(1)
         eq_(prices['name'], sample_price['name'])

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -11,6 +11,7 @@ class SlumberWrapper(object):
 
     def __init__(self, url):
         self.slumber = API(url)
+        self.api = self.slumber.api.v1
 
     def parse_res(self, res):
         if res == '':

--- a/webpay/pay/tasks.py
+++ b/webpay/pay/tasks.py
@@ -218,11 +218,11 @@ def get_icon_url(request):
         'size': size
     }
     try:
-        res = mkt_client.slumber.api.webpay.product.icon.get_object(**data)
+        res = mkt_client.api.webpay.product.icon.get_object(**data)
         return res['url']
     except ObjectDoesNotExist:
         # Queue the image to be fetched, resized and cached.
-        mkt_client.slumber.api.webpay.product.icon.post(data)
+        mkt_client.api.webpay.product.icon.post(data)
         # The URL will be fetched on next purchase.
         return None
 

--- a/webpay/pay/utils.py
+++ b/webpay/pay/utils.py
@@ -106,7 +106,7 @@ def send_pay_notice(url, notice_type, signed_notice, trans_id,
 
 def notify_failure(url, trans_id):
     statsd.incr('purchase.send_pay_notice.failure')
-    client.slumber.api.webpay.failure(trans_id).patch({
+    client.api.webpay.failure(trans_id).patch({
                 'attempts': settings.POSTBACK_ATTEMPTS,
                 'url': url})
     log.exception('Retries failed to %s: %s:' % (url, trans_id))


### PR DESCRIPTION
...)
