### PR TITLE
Improved JS pin validation (864703, 865661)

### DIFF
--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -8,6 +8,28 @@ require(['cli'], function(cli) {
     var currentInput = null;
     var interval = false;
 
+    // KeyCodes that aren't blocked.
+    var acceptedKeyCodes = [
+        8,  // backspace
+        9,  // tab
+        13, // enter/Go
+        27  // escape
+    ];
+
+    function isAllowedKeyEvent(e) {
+        // Checks for other ok key events such as backspace, tab etc.
+        return _.contains(acceptedKeyCodes, e.keyCode);
+    }
+
+    function isNumericKeyEvent(e){
+        var charCode = e.charCode;
+        // Meta / Alt / Ctrl / Shift keys
+        var isCombo = e.shiftKey || e.metaKey || e.ctrlKey || e.altKey;
+        // 0-9
+        var isNumeric = charCode >= 48 && charCode <= 57;
+        return !isCombo && isNumeric;
+    }
+
     function watchInput(i) {
         stopWatching();
 
@@ -25,23 +47,28 @@ require(['cli'], function(cli) {
         }, 100);
     }
 
-    function warn(msg) {
+    function showError(msg) {
         $errorMsg.text(msg);
         $pinBox.addClass('error');
         $forgotPin.hide();
         $submitButton.prop('disabled', true);
     }
 
+    function clearError() {
+        $pinBox.removeClass('error');
+        $forgotPin.show();
+    }
+
     function validate() {
         var value = $pinInput.val();
-        if (!value || value.length < 4) {
-            warn(cli.bodyData.pinShortWarning);
+        if (!value || value.length != PINLENGTH) {
+            showError(cli.bodyData.pinNumCharsWarning);
             return false;
         }
 
         var re = new RegExp('^[0-9]{4}$');
         if (!re.test(value)) {
-            warn(cli.bodyData.pinNonNumericWarning);
+            showError(cli.bodyData.pinNonNumericWarning);
             return false;
         }
 
@@ -81,10 +108,24 @@ require(['cli'], function(cli) {
         stopWatching();
     }).on('click', '.pinbox', function(e) {
         $pinInput.focus();
+    }).on('keypress', '.pinbox input', function(e) {
+        // Prevent more than 4 numbers in webkit.
+        if ($(this).val().length == PINLENGTH) {
+            return false;
+        }
+        // Don't show error for backspace/tab etc.
+        if (!isAllowedKeyEvent(e) && !isNumericKeyEvent(e)) {
+            showError(cli.bodyData.pinNonNumericWarning);
+            return false;
+        }
+        // Clear any error and allow the keypress.
+        clearError();
+        return true;
     });
 
     $('#pin').on('submit', function() {
         var isValid = validate();
+        $submitButton.prop('disabled', true);
         return isValid ? cli.showProgress() : false;
     });
 

--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -24,7 +24,7 @@
     data-logged-in-user="{{ session.get('logged_in_user', '') }}"
     data-reset-user-url="{{ url('auth.reset_user') }}"
     data-bango-logout-url="{{ settings.BANGO_LOGOUT_URL }}"
-    data-pin-short-warning="{{ _('Pin must be 4 digits.') }}"
+    data-pin-num-chars-warning="{{ _('Pin must be 4 digits.') }}"
     data-pin-non-numeric-warning="{{ _('Pin can only contain digits.') }}"
     data-loading-msg="{{ _('Loading') }}"
     data-begin-msg="{{ _('Beginning payment&hellip;') }}"

--- a/webpay/pin/forms.py
+++ b/webpay/pin/forms.py
@@ -17,6 +17,8 @@ class BasePinForm(ParanoidForm):
         self.fields['pin'].widget.attrs.update({
             'autocomplete': 'off',
             'type': 'number',
+            # Digit only keyboard for B2G (bug 820268).
+            'x-inputmode': 'digits',
         })
 
     def append_to_errors(self, field, error):


### PR DESCRIPTION
This branch checks the keypress event on the input to only allow valid input. Eventually pin inputs on B2G will be with a numeric only keyboard hence the addition of the x-inputmode attribute on the input field.

This is far from ideal as an approach - however, unfortunately validating the pin  by value is very problematic because as soon as the value becomes invalid the value from JS is an empty string and we can't use a more liberal input type because type=number is needed to bring up the correct keyboard. In addition in B2g there's no way to know the field is invalid programatically when the value becomes an empty string.
