### PR TITLE
Ensure focus fires and log focus event (bug 863328)

### DIFF
--- a/media/js/pay/pay.js
+++ b/media/js/pay/pay.js
@@ -24,7 +24,7 @@ require(['cli', 'id', 'auth', 'pay/bango'], function(cli, id, auth, bango) {
     function focusOnPin() {
         $('.message').hide();
         $('#enter-pin').fadeIn();
-        $('#pin [name="pin"]')[0].focus();
+        $('#pin [name="pin"]').focus();
     }
 
     if (bodyData.flow === 'lobby') {

--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -72,6 +72,7 @@ require(['cli'], function(cli) {
     }
 
     $(window).on('focus', '.pinbox input', function(e) {
+        console.log('[pin] focused');
         this.value = '';
         $pinBox.removeClass('error');
         $submitButton.prop('disabled', true);
@@ -92,8 +93,5 @@ require(['cli'], function(cli) {
         var pinClass = hasError ? ' class="filled"' : '';
         box.html(Array(PINLENGTH+1).join('<span'+pinClass+'></span>'));
         $el.prepend(box);
-        if (!hasError) {
-            $el.find('input').focus();
-        }
     });
 });


### PR DESCRIPTION
This switches focus to using Jquery rather than direct on the elm itself. Also added logging for the focus event. Oddly if it's direct on the element it doesn't appear to call focus event whereas the JQuery version does. 

I've also removed the focus that was previously happening after the pin boxes were created so there's only a single focus event.

This doesn't actually fix the problem but the logs show focus is being called, just that the keyboard isn't raising except on first run.
