### PR TITLE
Upgrading celery and dependent libraries (bug 825938)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,13 +1,13 @@
-amqplib==1.0.2
+amqp==1.0.11
 Babel==0.9.6
 Django==1.4.5
 anyjson==0.3.3
 billiard==2.7.3.17
 cef==0.5
-celery==2.5.1
+celery==3.0.19
 curling==0.2.6
 dj-database-url==0.2.1
-django-celery==2.2.4
+django-celery==3.0.17
 django-mobility==0.1
 django-multidb-router==0.5
 django-nose==1.1
@@ -21,7 +21,7 @@ gunicorn==0.14.6
 httplib2==0.7.6
 importlib-no-failure==1.0.2
 jingo==0.4
-kombu==2.1.2
+kombu==2.5.10
 mock==1.0b1
 mozpay==2.0.0
 nose==1.2.1


### PR DESCRIPTION
Note: Don't merge until the backend is ready to upgrade rabbitmq.
