### PR TITLE
Make pin form provide type attr (bug 874470)

### DIFF
--- a/media/js/pay/pay.js
+++ b/media/js/pay/pay.js
@@ -7,11 +7,6 @@ require(['cli', 'id', 'auth', 'pay/bango'], function(cli, id, auth, bango) {
     // can (and will have to) put a better value here. (bug 843192)
     var loggedIn = false;
 
-    $('[name="pin"]').each(function() {
-        this.type = 'number';
-        this.setAttribute('placeholder', '****');
-    });
-
     var onLogout = function() {
         // This is the default onLogout but might be replaced by other handlers.
         console.log('[pay] default onLogout');

--- a/webpay/pin/forms.py
+++ b/webpay/pin/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.forms.util import ErrorList
+from django.forms.widgets import TextInput
 from django.views.decorators.debug import sensitive_variables
 
 from django_paranoia.forms import ParanoidForm
@@ -8,15 +9,22 @@ from tower import ugettext_lazy as _
 from lib.solitude.api import client
 
 
+class HTML5NumberWidget(TextInput):
+    """An HTML5 number input widget."""
+    input_type = 'number'
+
+
 class BasePinForm(ParanoidForm):
-    pin = forms.CharField(max_length=4, required=True)
+    pin = forms.CharField(max_length=4, required=True,
+                          widget=HTML5NumberWidget)
 
     def __init__(self, uuid=None, *args, **kwargs):
         self.uuid = uuid
         super(BasePinForm, self).__init__(*args, **kwargs)
         self.fields['pin'].widget.attrs.update({
             'autocomplete': 'off',
-            'type': 'number',
+            'max': '9999',
+            'placeholder': '****',
             # Digit only keyboard for B2G (bug 820268).
             'x-inputmode': 'digits',
         })

--- a/webpay/pin/tests/test_forms.py
+++ b/webpay/pin/tests/test_forms.py
@@ -14,6 +14,19 @@ class BasePinFormTestCase(TestCase):
         self.data = {'pin': '1234'}
 
 
+class PinFormOutputTest(BasePinFormTestCase):
+
+    @patch.object(client, 'get_buyer', lambda x: {})
+    def test_html_form_attrs(self):
+        form = forms.CreatePinForm(uuid=self.uuid, data=self.data)
+        form_html = form.as_p()
+        assert 'type="number"' in form_html
+        assert 'autocomplete="off"' in form_html
+        assert 'placeholder="****"' in form_html
+        assert 'x-inputmode="digits"' in form_html
+        assert 'max="9999"' in form_html
+
+
 class CreatePinFormTest(BasePinFormTestCase):
 
     @patch.object(client, 'get_buyer', lambda x: {})


### PR DESCRIPTION
Adds the type="number" via the form rather than from JS and adds tests to check the output.
