### PR TITLE
Centralize focus handling (bug 863328)

### DIFF
--- a/media/css/pay/normalize.less
+++ b/media/css/pay/normalize.less
@@ -79,6 +79,8 @@ html {
 
 body {
     margin: 0;
+    // Kill outline on webkit
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
 
 /* ==========================================================================

--- a/media/css/pay/pay.less
+++ b/media/css/pay/pay.less
@@ -47,13 +47,14 @@ a:focus {
 }
 
 .progress {
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
+    background: @bg-main-cont;
+    background: rgba(244,244,244,0.9);
     bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
     z-index: 20;
-    background: rgba(244,244,244,0.90);
 }
 
 .progress .txt {
@@ -121,7 +122,6 @@ form footer button[type=submit] {
         text-align: center;
         top: 0;
         width: 100%;
-
         &::-moz-placeholder {
           color: #888;
           font-family: monospace;

--- a/media/js/cli.js
+++ b/media/js/cli.js
@@ -19,6 +19,25 @@ define('cli', [], function() {
             if ($progress.length) {
                 $progress.hide();
             }
+        },
+        focusOnPin: function(config) {
+            config = config || {};
+            var $form = config.$form || $('#pin');
+            var $toHide = config.$toHide || null;
+            var $toFadeIn = config.$toFadeIn || null;
+            var $pinBox = $form.find('.pinbox');
+            var $input = $form.find('input[name="pin"]');
+            if ($toHide && $toHide.length) {
+                $toHide.hide();
+            }
+            this.hideProgress();
+            if ($toFadeIn && $toFadeIn.length) {
+                $toFadeIn.fadeIn();
+            }
+            if (!$pinBox.hasClass('error')) {
+                console.log('[cli] Focusing pin');
+                $input.focus();
+            }
         }
     };
 });

--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -141,5 +141,7 @@ require(['cli'], function(cli) {
         var pinClass = hasError ? ' class="filled"' : '';
         box.html(Array(PINLENGTH+1).join('<span'+pinClass+'></span>'));
         $el.prepend(box);
+        console.log('[pin] requesting focus on pin');
+        cli.focusOnPin();
     });
 });

--- a/media/js/pin/reset.js
+++ b/media/js/pin/reset.js
@@ -6,20 +6,20 @@ require(['cli', 'id', 'pay/bango'], function(cli, id, bango) {
     function watchForceAuth(on_success) {
         id.watch({
             onlogin: function _resetLogin(assertion) {
-                console.log('reset: nav.id onlogin');
+                console.log('[reset] nav.id onlogin');
                 $.post(bodyData.verifyUrl, {assertion: assertion})
                     .success(function _resetLoginSuccess(data, textStatus, jqXHR) {
-                        console.log('login success');
+                        console.log('[reset] login success');
                         bango.prepareUser(data.user_hash).done(function() {
                             on_success.apply(this);
                         });
                     })
                     .error(function _resetLoginError() {
-                        console.log('login error');
+                        console.log('[reset] login error');
                     });
             },
             onlogout: function _resetLogout() {
-                console.log('nav.id onlogout');
+                console.log('[reset] nav.id onlogout');
             }
         });
     }
@@ -38,9 +38,8 @@ require(['cli', 'id', 'pay/bango'], function(cli, id, bango) {
         cli.showProgress(bodyData.personaMsg);
         if (window.localStorage.getItem('reset-step') === 'pin') {
             /* You've already re-signed in. */
-            cli.hideProgress();
-            $('#confirm-pin-reset').hide();
-            $('#enter-pin').fadeIn();
+            console.log('[reset] requesting focus on pin (already re-signed in)');
+            cli.focusOnPin({ $toHide: $('#confirm-pin-reset'), $toFadeIn: $('#enter-pin') });
             window.localStorage.removeItem('reset-step');
             return;
         }
@@ -57,9 +56,8 @@ require(['cli', 'id', 'pay/bango'], function(cli, id, bango) {
                 /* You are in the reset step and you've logged in,
                  * let's show you a pin.
                  */
-                cli.hideProgress();
-                $('#confirm-pin-reset').hide();
-                $('#enter-pin').fadeIn();
+                console.log('[reset] requesting focus on pin (logged-in)');
+                cli.focusOnPin({ $toHide: $('#confirm-pin-reset'), $toFadeIn: $('#enter-pin') });
             };
         }
         watchForceAuth(on_success);


### PR DESCRIPTION
This branch puts the focus handling in one place to make it easier to log what's happening. Also focusing has been added where it wasn't happening before.

There's still an issue with B2g but it's become very clear that this is some kind of platform bug.

I think with b2g what's happening intermittently is that the real focus event dies for some reason but because it's called via JQuery the JQuery event machinery does appear to fire even though the field doesn't end up actually focused. This explains why $foo[0].focus() didn't work.
