### PR TITLE
Allow non-simulations because we have a whitelist

### DIFF
--- a/webpay/settings/sites/prod/settings_base.py
+++ b/webpay/settings/sites/prod/settings_base.py
@@ -68,7 +68,6 @@ SYSLOG_TAG = private.SYSLOG_TAG
 # HTTPS to disable HTTPS-only cookies.
 SESSION_COOKIE_SECURE = True
 
-DOMAIN = 'marketplace.firefox.com'
 ISSUER = DOMAIN
 NOTIFY_ISSUER = DOMAIN
 VERBOSE_LOGGING = False
@@ -89,9 +88,6 @@ ALLOWED_CALLBACK_SCHEMES = ['https']
 BANGO_BASE_URL = 'https://mozilla.bango.net'
 BANGO_PAY_URL = BANGO_BASE_URL + '/mozpayments/?bcid=%s'
 BANGO_LOGOUT_URL = '%s/mozpayments/logout/' % BANGO_BASE_URL
-
-# Temporarily only accept simulations while we work to get Bango online.
-ONLY_SIMULATIONS = True
 
 STATSD_HOST = private.STATSD_HOST
 STATSD_PORT = private.STATSD_PORT


### PR DESCRIPTION
This is mainly needed for debugging in bug 886928.
This also fixes DOMAIN which was defined twice.
