### PR TITLE
Focus trusted-ui to ensure reliable keyboard appearance (bug 863328)

### DIFF
--- a/media/js/cli.js
+++ b/media/js/cli.js
@@ -21,6 +21,13 @@ define('cli', [], function() {
             }
         },
         focusOnPin: function(config) {
+            // Ensure the trusted-ui is currently in focus
+            // which is necessary to ensure the reliability of
+            // the keyboard appearing when we focus the input
+            // (bug 863328).
+            if (window.focus) {
+                window.focus();
+            }
             config = config || {};
             var $form = config.$form || $('#pin');
             var $toHide = config.$toHide || null;


### PR DESCRIPTION
This seems stupidly simple, but after noticing that if I click on the trusted-ui header the keyboard comes up every time, this is all it took to make sure the trusted-ui handles the input focus more reliably. For me this makes the keyboard come up every time.
