### PR TITLE
Fix button text overflow (bug 889534)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+    "globals": {
+        "_": false,
+        "$": false,
+        "document": false,
+        "DocumentTouch": false,
+        "console": false,
+        "navigator": false,
+        "window": false
+    }
+}

--- a/media/css/pay/pay.styl
+++ b/media/css/pay/pay.styl
@@ -12,6 +12,7 @@ body {
     font-weight: 400;
     line-height: 22px;
     margin: 0;
+    overflow-x: hidden;
     &.error-page {
         padding: 10px;
     }
@@ -53,7 +54,6 @@ a:focus {
     top: 0;
     z-index: 20;
 }
-
 .progress .txt {
     display: block;
     margin-top: 20px;
@@ -62,12 +62,16 @@ a:focus {
 
 section.pay {
     margin: 0 auto;
-    max-height: 480px;
     max-width: 600px;
     min-height: 100%;
+    padding-bottom: 50px;
     position: relative;
     width: 100%;
     word-wrap: break-word;
+}
+
+.longtext .pay {
+    padding-bottom: 150px;
 }
 
 pre {
@@ -75,23 +79,26 @@ pre {
     word-wrap: break-word;
 }
 
-form {
-    padding-bottom: 50px;
-}
-
 footer {
     background: rgba(0, 0, 0, 0.03);
     border-top: 1px solid $light-gray;
     bottom: 0;
     left: 0;
+    opacity: 0;
     padding: 10px 20px;
     position: absolute;
+    transition(opacity 1s ease-in);
     width: 100%;
-}
-
-footer button,
-footer .button {
-    width: 47%;
+    &.longtext .button {
+        margin: 5px 0;
+        width: 100%;
+    }
+    &.visible {
+        opacity: 1;
+    }
+    .button {
+        width: 47%;
+    }
 }
 
 .lock-continue,
@@ -204,25 +211,27 @@ footer button[type=submit] {
 }
 
 /* Buttons */
-.button,
 a.button,
-button {
-    gradient-two-color(#00CAF2, #00AACC);
+.button {
     border-radius: 3px;
     border: 1px solid #00AACC;
     color: $dark-gray;
     display: inline-block;
     font: 600 14px/40px $open-stack;
+    gradient-two-color(#00CAF2, #00AACC);
     height: 40px;
+    overflow: hidden;
     padding: 0 10px;
     position: relative;
     text-align: center;
     text-decoration: none;
+    text-overflow: ellipsis;
     text-shadow: 0 1px 0 #fff;
     white-space: nowrap;
 
     &::-moz-focus-inner {
-        border: none;
+        border: 0;
+        padding: 0 10px;
     }
 
     &.sec {
@@ -250,6 +259,7 @@ button {
         background: #e7e7e7;
         border-color: #c7c7c7;
         color: #c7c7c7;
+        padding: 0 10px;
         pointer-events: none;
         text-shadow: none;
     }

--- a/media/js/cli.js
+++ b/media/js/cli.js
@@ -2,8 +2,12 @@ define('cli', [], function() {
     'use strict';
 
     var $progress = $('#progress');
+    var $doc = $(document);
+    var $win = $(window);
 
     return {
+        win: $win,
+        doc: $doc,
         hasTouch: ('ontouchstart' in window) ||
                    window.DocumentTouch &&
                    document instanceof DocumentTouch,
@@ -31,17 +35,18 @@ define('cli', [], function() {
             config = config || {};
             var $form = config.$form || $('#pin');
             var $toHide = config.$toHide || null;
-            var $toFadeIn = config.$toFadeIn || null;
+            var $toShow = config.$toShow || null;
             var $pinBox = $form.find('.pinbox');
             var $input = $form.find('input[name="pin"]');
             if ($toHide && $toHide.length) {
                 $toHide.hide();
             }
             this.hideProgress();
-            if ($toFadeIn && $toFadeIn.length) {
-                $toFadeIn.fadeIn();
+            if ($toShow && $toShow.length) {
+                $toShow.show();
+                $doc.trigger('check-long-text');
             }
-            if (!$pinBox.hasClass('error')) {
+            if ($pinBox.length && !$pinBox.hasClass('error')) {
                 console.log('[cli] Focusing pin');
                 $input.focus();
             }

--- a/media/js/lib/longtext.js
+++ b/media/js/lib/longtext.js
@@ -1,0 +1,61 @@
+/*
+ * This function detects text overflow in single line text.
+ * When any elements checked have textoverflow, LONGTEXTCLASS is applied to
+ * elements or supplied selector.
+ *
+ * Should be run in initialisation and when viewport is resized.
+ */
+define('lib/longtext', [], function() {
+
+    var $doc = $(document);
+    var HASLONGTEXTCLASS = 'longtext';
+
+    var hidden = $('<div style="visibility:hidden;position:absolute;white-space:nowrap;top:0;"></div>') ;
+    var currentVpWidth;
+
+    $('body').append(hidden);
+
+    function checkOverflow(el, allowForEllipsis) {
+        // Add the text from 'el' to the 'hidden' element
+        // and compare the width to see if text is overflowing.
+        allowForEllipsis = allowForEllipsis === true ? 5 : 0;
+        var $el = $(el);
+        hidden.text($el.text());
+        hidden.css('font-size', $el.css('font-size'));
+        return ($el.width() - allowForEllipsis) < hidden.width();
+    }
+
+    $.fn.checkLongText = function($longTextElms, allowForEllipsis) {
+
+        // $longTextElms allows placing a classname somewhere to control a group of items
+        // rather than adding the class to individuals.
+        var $elmsToCheck = this;
+        $longTextElms = $longTextElms.length ? $longTextElms : $elmsToCheck;
+        var hasLongText = false;
+
+        // Bail if nothing is visible as we won't be able
+        // to carry out a check successfully.
+        if ($elmsToCheck.is(':hidden')) {
+            return;
+        }
+
+        var vpWidth = $(window).width();
+        // no-op if the viewport size hasn't change since last time.
+        if ($elmsToCheck.length && currentVpWidth != vpWidth) {
+            console.log('[longtext] Checking text overflow');
+            // Remove the class to be able to make a fair comparison.
+            $longTextElms.removeClass(HASLONGTEXTCLASS);
+            $elmsToCheck.each(function() {
+                if (checkOverflow(this, allowForEllipsis) === true) {
+                    hasLongText = true;
+                    return false;
+                }
+            });
+            $longTextElms.toggleClass(HASLONGTEXTCLASS, hasLongText);
+        }
+        currentVpWidth = vpWidth;
+        $doc.trigger('post-longtext-check');
+
+        return $elmsToCheck;
+    };
+});

--- a/media/js/pin/reset.js
+++ b/media/js/pin/reset.js
@@ -39,7 +39,7 @@ require(['cli', 'id', 'pay/bango'], function(cli, id, bango) {
         if (window.localStorage.getItem('reset-step') === 'pin') {
             /* You've already re-signed in. */
             console.log('[reset] requesting focus on pin (already re-signed in)');
-            cli.focusOnPin({ $toHide: $('#confirm-pin-reset'), $toFadeIn: $('#enter-pin') });
+            cli.focusOnPin({ $toHide: $('#confirm-pin-reset'), $toShow: $('#enter-pin') });
             window.localStorage.removeItem('reset-step');
             return;
         }
@@ -57,7 +57,7 @@ require(['cli', 'id', 'pay/bango'], function(cli, id, bango) {
                  * let's show you a pin.
                  */
                 console.log('[reset] requesting focus on pin (logged-in)');
-                cli.focusOnPin({ $toHide: $('#confirm-pin-reset'), $toFadeIn: $('#enter-pin') });
+                cli.focusOnPin({ $toHide: $('#confirm-pin-reset'), $toShow: $('#enter-pin') });
             };
         }
         watchForceAuth(on_success);

--- a/webpay/pay/templates/pay/simulate.html
+++ b/webpay/pay/templates/pay/simulate.html
@@ -17,7 +17,7 @@
           <a class="button cancel-button" href="#">
             {{ _('Cancel') }}
           </a>
-          <button type="submit">{{ _('Continue') }}</button>
+          <button class="button" type="submit">{{ _('Continue') }}</button>
       </footer>
     </form>
   </p>

--- a/webpay/pin/templates/pin/pin_form.html
+++ b/webpay/pin/templates/pin/pin_form.html
@@ -30,15 +30,15 @@
 
       <footer>
         {% if form.reset_flow  %}
-          <a class="button sec" href="{{ url('pin.reset_cancel') }}">
+          <a class="button ltchk sec" href="{{ url('pin.reset_cancel') }}">
             {{ _('Cancel') }}
           </a>
         {% else %}
-          <a class="button cancel-button sec" href="#">
+          <a class="button cancel-button ltchk sec" href="#">
             {{ _('Cancel') }}
           </a>
         {% endif %}
-        <button disabled type="submit">{{ _('Continue') }}</button>
+        <button disabled class="button ltchk" type="submit">{{ _('Continue') }}</button>
       </footer>
     </form>
   </div>

--- a/webpay/pin/templates/pin/pin_was_locked.html
+++ b/webpay/pin/templates/pin/pin_was_locked.html
@@ -9,10 +9,10 @@
   <h2>{{ _('Your Pin was locked') }}</h2>
   <p>{{ _('Your pin was locked because you entered it incorrectly too many times. You can continue and try entering your pin again or reset your pin.') }}</p>
   <footer>
-    <a id="do-reset" class="button sec" href="{{ url('pin.reset_start') }}">
+    <a id="do-reset" class="button ltchk sec" href="{{ url('pin.reset_start') }}">
       {{ _('Reset Pin') }}
     </a>
-    <a class="button lock-continue" href="{{ url('pin.verify') }}">
+    <a class="button lock-continue ltchk" href="{{ url('pin.verify') }}">
       {{ _('Continue') }}
     </a>
   </footer>

--- a/webpay/pin/templates/pin/reset_start.html
+++ b/webpay/pin/templates/pin/reset_start.html
@@ -12,10 +12,10 @@
   <h2>{{ _('Forgot your pin?') }}</h2>
   <p>{{ _('Are you sure you want to reset your pin? You must sign in to Persona to reset your pin.') }}</p>
   <footer>
-    <a class="button sec" href="{{ url('pin.reset_cancel') }}">
+    <a class="button ltchk sec" href="{{ url('pin.reset_cancel') }}">
       {{ _('Cancel') }}
     </a>
-    <a id="do-reset" class="button force-auth-button reset-pin" href="javascript:false">
+    <a id="do-reset" class="button force-auth-button ltchk reset-pin" href="javascript:false">
       {{ _('Reset') }}
     </a>
   </footer>

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -47,6 +47,7 @@ MINIFY_BUNDLES = {
             'js/lib/require.js',
             'js/lib/underscore.js',
             'js/lib/format.js',
+            'js/lib/longtext.js',
 
             # These are modules used by others.
             # The order is important, do not alphabetize.

--- a/webpay/urls.py
+++ b/webpay/urls.py
@@ -35,12 +35,17 @@ urlpatterns = patterns('',
 if settings.TEMPLATE_DEBUG:
 
     from django.views.defaults import page_not_found, server_error
+    from django.views.generic.simple import direct_to_template
 
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
     urlpatterns += patterns('',
         url(r'^404$', page_not_found, name="error_404"),
         url(r'^500$', server_error, name="error_500"),
+        (r'^was-locked/$', direct_to_template,
+         {'template': 'pin/pin_was_locked.html'} ),
+        (r'^is-locked/$', direct_to_template,
+         {'template': 'pin/pin_is_locked.html'} ),
         (r'^%s/(?P<path>.*)$' % media_url, 'django.views.static.serve',
          {'document_root': settings.MEDIA_ROOT}),
     )


### PR DESCRIPTION
Instead of just using text-overflow: ellipsis this now has script to detect text overflow and stack the buttons when it doesn't fit.

As part of the same branch I've removed the fadeIn and moved that to simply show/hide as this helps speed up detection. Lastly transitioning in the footer hides the switch to stacked buttons.

Views have been added to webpay to directly show some of the templates when in local development. For example /was-locked/?lang=es is a good url to look at.

![web_pay 2](https://f.cloud.github.com/assets/1514/811640/7f09f2ca-eedc-11e2-8120-abf574035bb0.png)
![web_pay](https://f.cloud.github.com/assets/1514/811641/80dc42b0-eedc-11e2-9a7b-60d4736b8d8e.png)
