### PR TITLE
Fix lint errors in id.js

### DIFF
--- a/media/js/id.js
+++ b/media/js/id.js
@@ -23,11 +23,11 @@ define('id', ['cli'], function(cli) {
                 // When we get a falsey user, set an undefined state
                 // which will trigger onlogout(),
                 // see https://developer.mozilla.org/en-US/docs/DOM/navigator.id.watch
-                loggedInUser: user || undefined,
+                loggedInUser: user || undefined
             };
             var params = $.extend({}, defaults, arguments[0]);
 
             navigator.id.watch(params);
         }
-    }
+    };
 });


### PR DESCRIPTION
Remove a trailing comma and missing semicolon in id.js that I noticed on my travels.
