### PR TITLE
Payment cancelled should have one instance with a period (899817)

### DIFF
--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -31,7 +31,7 @@
     data-begin-msg="{{ _('Beginning payment&hellip;') }}"
     data-persona-msg="{{ _('Connecting to Persona') }}"
     data-complete-msg="{{ _('Payment complete') }}"
-    data-cancelled-msg="{{ _('Payment cancelled') }}"
+    data-cancelled-msg="{{ _('Payment cancelled.') }}"
     data-logout-timeout="{{ settings.LOGOUT_TIMEOUT }}"
     >
     <section class="pay">


### PR DESCRIPTION
This converts to having just one case of "Payment cancelled" that ends in a '.' rather than two.
