### PR TITLE
Link to cdn directly (bug 905117)

### DIFF
--- a/webpay/settings/sites/dev/settings_base.py
+++ b/webpay/settings/sites/dev/settings_base.py
@@ -54,6 +54,9 @@ MARKETPLACE_URL = SITE_URL
 MARKETPLACE_OAUTH = {'key': private.MARKETPLACE_OAUTH_KEY,
                      'secret': private.MARKETPLACE_OAUTH_SECRET}
 
+STATIC_URL = getattr(private, 'STATIC_URL', 'https://marketplace-dev-cdn.allizom.org/')
+MEDIA_URL = STATIC_URL + 'mozpay/media/'
+
 #LOGIN_URL = '/mozpay'
 
 # Playdoh ships with Bcrypt+HMAC by default because it's the most secure.

--- a/webpay/settings/sites/prod/settings_base.py
+++ b/webpay/settings/sites/prod/settings_base.py
@@ -45,6 +45,9 @@ MARKETPLACE_URL = SITE_URL
 MARKETPLACE_OAUTH = {'key': private.MARKETPLACE_OAUTH_KEY,
                      'secret': private.MARKETPLACE_OAUTH_SECRET}
 
+STATIC_URL = getattr(private, 'STATIC_URL', 'https://marketplace.cdn.mozilla.net/')
+MEDIA_URL = STATIC_URL + 'mozpay/media/'
+
 HMAC_KEYS = private.HMAC_KEYS
 
 from django_sha2 import get_password_hashers

--- a/webpay/settings/sites/stage/settings_base.py
+++ b/webpay/settings/sites/stage/settings_base.py
@@ -45,6 +45,9 @@ MARKETPLACE_URL = SITE_URL
 MARKETPLACE_OAUTH = {'key': private.MARKETPLACE_OAUTH_KEY,
                      'secret': private.MARKETPLACE_OAUTH_SECRET}
 
+STATIC_URL = getattr(private, 'STATIC_URL', 'https://marketplace-cdn.allizom.org/')
+MEDIA_URL = STATIC_URL + 'mozpay/media/'
+
 HMAC_KEYS = private.HMAC_KEYS
 
 from django_sha2 import get_password_hashers


### PR DESCRIPTION
This gets rid of the need to 301 to the CDN resources as we link to static assets directly on the CDN.
