### PR TITLE
Convert form errors to dev codes (bug 887471)

### DIFF
--- a/webpay/base/dev_messages.py
+++ b/webpay/base/dev_messages.py
@@ -1,0 +1,91 @@
+from django.conf import settings
+
+from tower import ugettext as _
+
+
+BAD_JWT_ISSUER = 'BAD_JWT_ISSUER'
+BAD_ICON_KEY = 'BAD_ICON_KEY'
+BAD_SIM_RESULT = 'BAD_SIM_RESULT'
+EXPIRED_JWT = 'EXPIRED_JWT'
+INVALID_JWT = 'INVALID_JWT'
+INVALID_JWT_OBJ = 'INVALID_JWT_OBJ'
+JWT_DECODE_ERR = 'JWT_DECODE_ERR'
+MALFORMED_URL = 'MALFORMED_URL'
+NO_DEFAULT_LOC = 'NO_DEFAULT_LOC'
+NO_SIM_REASON = 'NO_SIM_REASON'
+SIM_DISABLED = 'SIM_DISABLED'
+SIM_ONLY_KEY = 'SIM_ONLY_KEY'
+
+SHORT_FIELDS = ('chargebackURL',
+                'defaultLocale',
+                'id',
+                'name',
+                'postbackURL',
+                'productData')
+
+# Map of field name to 'too long' error code.
+SHORT_FIELD_TOO_LONG_CODE = {}
+
+# Convert all short fields into error codes.
+# E.G. CHARGEBACKURL_TOO_LONG
+for fn in SHORT_FIELDS:
+    cd = '{0}_TOO_LONG'.format(fn.upper())
+    SHORT_FIELD_TOO_LONG_CODE[fn] = cd
+
+
+def legend():
+    """
+    Legend of error message codes for developers.
+
+    These codes are used in validation but will be slightly hidden from users
+    so as not to cause confusion. The legend is a reference for
+    developers.
+    """
+    _legend = {
+        BAD_ICON_KEY:
+            # L10n: First argument is an example of the proper key format.
+            _('An image icon key was not an object. Correct example: {0}')
+            .format('{"64": "https://.../icon_64.png"}'),
+        # L10n: JWT stands for JSON Web Token and does not need to be
+        # localized.
+        BAD_JWT_ISSUER: _('No one has been registered for this JWT issuer.'),
+        BAD_SIM_RESULT:
+            _('The requested payment simulation result is not supported.'),
+        # L10n: JWT stands for JSON Web Token and does not need to be
+        # localized.
+        EXPIRED_JWT: _('The JWT has expired.'),
+        INVALID_JWT:
+            # L10n: JWT stands for JSON Web Token and does not need to be
+            # localized.
+            _('The JWT signature is invalid or the JWT is malformed.'),
+        # L10n: JWT stands for JSON Web Token and does not need to be
+        # localized.
+        INVALID_JWT_OBJ: _('The JWT did not decode to a JSON object.'),
+        # L10n: JWT stands for JSON Web Token and does not need to be
+        # localized.
+        JWT_DECODE_ERR: _('Error decoding JWT.'),
+        # L10n: 'postback' is a term that means a URL accepting HTTP posts.
+        MALFORMED_URL: _('A URL is malformed. This could be a postback '
+                         'URL or an icon URL.'),
+        NO_DEFAULT_LOC:
+            # L10n: First and second arguements are the names of keys.
+            _('If {0} is defined, then you must also define {1}.')
+            .format('locales', 'defaultLocale'),
+        NO_SIM_REASON:
+            # L10n: First argument is the name of the key, 'reason'.
+            _("The requested chargeback simulation is missing "
+              "the key '{0}'.").format('reason'),
+        SIM_DISABLED: _('Payment simulations are disabled at this time.'),
+        SIM_ONLY_KEY:
+            _('This payment key can only be used to simulate purchases.'),
+    }
+
+    # Define all short field too long errors.
+    for field, key in SHORT_FIELD_TOO_LONG_CODE.iteritems():
+        # L10n: First argument is the name of a key. Second
+        # argument is a number.
+        _legend[key] = _('The value for key "{0}" exceeds the maximum '
+                         'length of {1}').format(
+                                field, settings.SHORT_FIELD_MAX_LENGTH)
+
+    return _legend

--- a/webpay/base/templates/error.html
+++ b/webpay/base/templates/error.html
@@ -8,6 +8,9 @@
   <div class="msg">
     <h2>{{ _('Error') }}</h2>
     <p>{{ error }}</p>
+    {% if code %}
+      <p>{{ code }}</p>
+    {% endif %}
   </div>
   <footer>
     <a class="button cancel-button" href="#">

--- a/webpay/base/tests/test_dev_messages.py
+++ b/webpay/base/tests/test_dev_messages.py
@@ -1,0 +1,10 @@
+from django import test
+
+from webpay.base.dev_messages import legend
+
+
+class TestDevMessages(test.TestCase):
+
+    def test_legend(self):
+        # Make sure there are no exceptions.
+        legend()

--- a/webpay/base/utils.py
+++ b/webpay/base/utils.py
@@ -28,11 +28,16 @@ def log_cef(msg, request, **kw):
     _log_cef(msg, severity, request.META.copy(), **cef_kw)
 
 
-def _error(request, msg='', exception=None, display=False):
-    external = _('There was an error processing that request.')
+def _error(request, msg='', exception=None, display=False,
+           code=None):
+    external = _('There was an error setting up the payment. '
+                 'Try again or contact the app if it persists.')
     if msg:
         log.error('Error handler: %s' % msg)
-    if settings.VERBOSE_LOGGING or display:
+
+    # Checking code here is is a short-term hack until all things send
+    # error codes.
+    if not code and (settings.VERBOSE_LOGGING or display):
         if exception:
             msg = u'%s: %s' % (exception.__class__.__name__, exception)
         if msg:
@@ -41,4 +46,6 @@ def _error(request, msg='', exception=None, display=False):
             # This should never happen but it might be happening.
             # See bug 864306
             log.error('No detailed error message/exception in handler')
-    return render(request, 'error.html', {'error': external}, status=400)
+
+    return render(request, 'error.html',
+                  {'error': external, 'code': code}, status=400)

--- a/webpay/pay/forms.py
+++ b/webpay/pay/forms.py
@@ -3,10 +3,10 @@ from django.conf import settings
 
 from django_paranoia.forms import ParanoidForm
 import jwt
-from tower import ugettext as _
 
 from lib.solitude.constants import ACCESS_SIMULATE
 
+from webpay.base import dev_messages as msg
 from webpay.base.logger import getLogger
 
 from .utils import lookup_issuer, UnknownIssuer
@@ -27,9 +27,8 @@ class VerifyForm(ParanoidForm):
         try:
             payload = jwt.decode(jwt_data, verify=False)
         except jwt.DecodeError, exc:
-            # L10n: first argument is a detailed error message.
-            err = _('Error decoding JWT: {0}').format(exc)
-            raise forms.ValidationError(err)
+            log.debug('Error decoding JWT: {0}'.format(exc))
+            raise forms.ValidationError(msg.JWT_DECODE_ERR)
         log.debug('Received JWT: %r' % payload)
         if not isinstance(payload, dict):
             # It seems that some JWT libs are encoding strings of JSON
@@ -37,10 +36,7 @@ class VerifyForm(ParanoidForm):
             # error. If it becomes a headache for developers we can make a
             # guess and check the string for a JSON object.
             log.info('JWT was not a dict, it was %r' % type(payload))
-            raise forms.ValidationError(
-                # L10n: first argument is a data type, such as <unicode>
-                _('The JWT did not decode to a JSON object. Its type was {0}.')
-                .format(type(payload)))
+            raise forms.ValidationError(msg.INVALID_JWT_OBJ)
 
         try:
             sim = payload['request']['simulate']
@@ -48,63 +44,42 @@ class VerifyForm(ParanoidForm):
             sim = False
         self.is_simulation = bool(sim) and isinstance(sim, dict)
         if self.is_simulation and not settings.ALLOW_SIMULATE:
-            raise forms.ValidationError(
-                _('Payment simulations are disabled at this time.'))
+            raise forms.ValidationError(msg.SIM_DISABLED)
 
         if self.is_simulation:
             # Validate simulations.
             if sim.get('result') not in settings.ALLOWED_SIMULATIONS:
-                raise forms.ValidationError(
-                    _('The requested simulation result is not supported.'))
+                raise forms.ValidationError(msg.BAD_SIM_RESULT)
             if sim['result'] == 'chargeback' and not sim.get('reason'):
-                raise forms.ValidationError(
-                    _("The requested chargeback simulation is missing the "
-                      "key '{0}'.").format('reason'))
+                log.info("chargeback simulation is missing the "
+                         "key '{0}'.".format('reason'))
+                raise forms.ValidationError(msg.NO_SIM_REASON)
 
         self.key = payload.get('iss', '')
         try:
             self.secret, active_product = lookup_issuer(self.key)
-        except UnknownIssuer, err:
-            raise forms.ValidationError(
-                # L10n: the first argument is a key to identify an issuer.
-                _('No one has been registered for JWT issuer {0}.')
-                .format(repr(self.key)))
+        except UnknownIssuer:
+            log.info('No one registered for JWT issuer {0}'
+                     .format(repr(self.key)))
+            raise forms.ValidationError(msg.BAD_JWT_ISSUER)
 
         if (active_product and active_product['access'] == ACCESS_SIMULATE
             and not self.is_simulation):
-            raise forms.ValidationError(
-                # L10n: the first argument is a key to identify an issuer.
-                _('This payment key, {0}, can only be used to simulate '
-                  'purchases.').format(repr(self.key)))
+            log.info('payment key {0} can only simulate, tried to purchase'
+                     .format(repr(self.key)))
+            raise forms.ValidationError(msg.SIM_ONLY_KEY)
 
         icons = payload['request'].get('icons', None)
         if icons and type(icons) != dict:
-            example = '{"64": "https://.../icon_64.png"}'
-            raise forms.ValidationError(
-                    # L10n: First argument is the name of a key. Second
-                    # argument is an example of the proper key format.
-                    _('The "{0}" key must be an object of '
-                      'URLs such as {1}').format('icons', example))
+            raise forms.ValidationError(msg.BAD_ICON_KEY)
 
-        max_size = settings.SHORT_FIELD_MAX_LENGTH
-        for fn in ('chargebackURL',
-                   'defaultLocale',
-                   'id',
-                   'name',
-                   'postbackURL',
-                   'productData'):
-            if len(payload['request'].get(fn, '')) > max_size:
-                raise forms.ValidationError(
-                        # L10n: First argument is the name of a key. Second
-                        # argument is a number.
-                        _('The value for key "{0}" exceeds the maximum '
-                          'length of {1}').format(fn, max_size))
+        for fn in msg.SHORT_FIELDS:
+            if (len(payload['request'].get(fn, '')) >
+                settings.SHORT_FIELD_MAX_LENGTH):
+                raise forms.ValidationError(msg.SHORT_FIELD_TOO_LONG_CODE[fn])
 
         if payload['request'].get('locales'):
             if not payload['request'].get('defaultLocale'):
-                raise forms.ValidationError(
-                    # L10n: First and second arguements are the names of keys.
-                    _('If {0} is defined, then you must also define {1}.')
-                        .format('locales', 'defaultLocale'))
+                raise forms.ValidationError(msg.NO_DEFAULT_LOC)
 
         return data

--- a/webpay/pay/tests/test_forms.py
+++ b/webpay/pay/tests/test_forms.py
@@ -36,24 +36,6 @@ class TestForm(Base):
     def test_broken(self):
         self.failed(VerifyForm({'req': 'foo'}))
 
-    def test_debug(self):
-        with self.settings(VERBOSE_LOGGING=True):
-            payload = self.request(app_secret=self.secret + '.nope')
-            res = self.get(payload)
-            eq_(res.status_code, 400)
-            # Output should show exception message.
-            self.assertContains(res,
-                                'InvalidJWT: Signature verification failed',
-                                status_code=400)
-
-    def test_not_debug(self):
-        with self.settings(VERBOSE_LOGGING=False):
-            payload = self.request(app_secret=self.secret + '.nope')
-            res = self.get(payload)
-            eq_(res.status_code, 400)
-            # Output should show a generic error message without details.
-            self.assertContains(res, 'There was an error', status_code=400)
-
 
 @mock.patch.object(settings, 'KEY', 'marketplace.mozilla.org')
 @mock.patch.object(settings, 'SECRET', 'marketplace.secret')


### PR DESCRIPTION
Incremental start in using error codes. Example:
![screen shot 2013-08-30 at 2 35 31 pm](https://f.cloud.github.com/assets/55398/1060467/bcfd1ce0-11b1-11e3-86bf-7eb1c086892c.png)
