### PR TITLE
Explicitly adding jingo_minify app (rel 871860 PR#270 PR#271)

### DIFF
--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = list(INSTALLED_APPS) + [
     'webpay.services',
     'tower',
     'raven.contrib.django',
+    'jingo_minify',
 ]
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a


### PR DESCRIPTION
In order to get access to the `compress_assets` command used in deployment.
