### PR TITLE
Explicitly declare all apps used.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,10 +7,8 @@ cef==0.5
 celery==3.0.19
 curling==0.2.8
 dj-database-url==0.2.1
-django-appconf==0.6
 django_csp==2.0.2
 django-celery==3.0.17
-django-compressor==1.3
 django-mobility==0.1
 django-multidb-router==0.5
 django-nose==1.1

--- a/settings_test.py
+++ b/settings_test.py
@@ -20,10 +20,6 @@ FAKE_PAYMENTS = False
 # persona throws.
 SITE_URL = 'http://testserver'
 
-# These were needed after upgrading funfactory.
-STATIC_URL = SITE_URL + '/media/'
-COMPRESS_URL = STATIC_URL
-
 ALLOW_SIMULATE = True
 TEST_PIN_UI = False
 

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -13,14 +13,36 @@ PROJECT_MODULE = 'webpay'
 # Defines the views served for root URLs.
 ROOT_URLCONF = '%s.urls' % PROJECT_MODULE
 
-INSTALLED_APPS = list(INSTALLED_APPS) + [
+INSTALLED_APPS = [
+
+    # Local apps
+    'funfactory',  # Content common to most playdoh-based apps.
+
+    'tower',  # for ./manage.py extract (L10n)
+    'django_browserid',
+
+    # Django contrib apps
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.staticfiles',
+
+    # Third-party apps, patches, fixes
+    'commonware.response.cookies',
+    'djcelery',
+    'django_nose',
+    'session_csrf',
+
+    # L10n
+    'product_details',
+
+    # Webpay apps.
     'webpay.auth',
     'webpay.base',  # Needed for global templates, etc.
     'webpay.bango',
     'webpay.pay',
     'webpay.pin',
     'webpay.services',
-    'tower',
     'raven.contrib.django',
     'jingo_minify',
 ]


### PR DESCRIPTION
Funfactory has some apps that we don't need
so this ensures we don't pick them up on upgrade.
