### PR TITLE
Better message for setting up payment

### DIFF
--- a/webpay/pay/templates/pay/wait-to-start.html
+++ b/webpay/pay/templates/pay/wait-to-start.html
@@ -8,6 +8,6 @@
 {% block content %}
 <div id="progress" class="progress">
   <div class="throbber"></div>
-  <span class="txt">{{ _('Waiting for payment to complete&hellip;') }}</span>
+  <span class="txt">{{ _('Setting up payment&hellip;') }}</span>
 </div>
 {% endblock %}

--- a/webpay/pay/tests/test_views.py
+++ b/webpay/pay/tests/test_views.py
@@ -414,7 +414,7 @@ class TestWaitToStart(Base):
     def test_wait(self, get_transaction):
         res = self.client.get(self.wait)
         eq_(res.status_code, 200)
-        self.assertContains(res, 'Waiting')
+        self.assertContains(res, 'Setting up payment')
 
 
 class TestSimulate(BasicSessionCase, JWTtester):


### PR DESCRIPTION
This message appears when webpay is waiting for the billing config API to grant a token. The old message is dangerously misleading; a user might think they are getting charged and they might cancel.
