### PR TITLE
Track events for GA (bug 903056)

### DIFF
--- a/media/js/auth.js
+++ b/media/js/auth.js
@@ -16,11 +16,15 @@ define('auth', ['cli'], function(cli) {
                 .done(function _resetSuccess(data, textStatus, jqXHR) {
                     console.log('reset webpay user');
                     window.localStorage.clear();
+                    cli.trackWebpayEvent({'action': 'webpay user reset',
+                                          'label': 'Reset User Success'});
                 })
                 .fail(function _resetFail(jqXHR, textStatus, errorThrown) {
                     console.log('error resetting user:', textStatus, errorThrown);
+                    cli.trackWebpayEvent({'action': 'webpay user reset',
+                                          'label': 'Reset User Error'});
                 });
             return result;
         }
-    }
+    };
 });

--- a/media/js/cli.js
+++ b/media/js/cli.js
@@ -1,9 +1,10 @@
-define('cli', [], function() {
+define('cli', ['settings', 'lib/tracking'], function(settings, tracking) {
     'use strict';
 
     var $progress = $('#progress');
     var $doc = $(document);
     var $win = $(window);
+    var gaTrackingCategory = settings.ga_tracking_category;
 
     var cli = {
         win: $win,
@@ -51,6 +52,18 @@ define('cli', [], function() {
                 console.log('[cli] Focusing pin');
                 $input.focus();
             }
+        },
+        trackWebpayClick: function(e) {
+            if (e && e.target) {
+                var trackEventData = $(e.target).data('trackEvent');
+                if (trackEventData) {
+                    this.trackWebpayEvent(trackEventData);
+                }
+            }
+        },
+        trackWebpayEvent: function(options) {
+            options = options || {};
+            tracking.trackEvent(gaTrackingCategory, options.action, options.label, options.value, options.nonInteraction);
         }
     };
 

--- a/media/js/pay/bango.js
+++ b/media/js/pay/bango.js
@@ -17,6 +17,8 @@ define('pay/bango', ['cli'], function(cli) {
                     console.log('[bango] new icc', iccKey, '!== saved icc', lastIcc);
                     changed = true;
                     console.log('[bango] sim changed');
+                    cli.trackWebpayEvent({'action': 'sim change detection',
+                                          'label': 'Sim Changed'});
                 } else {
                     console.log('[bango] sim did not change');
                 }
@@ -45,6 +47,8 @@ define('pay/bango', ['cli'], function(cli) {
 
             if (existingUser && existingUser !== userHash) {
                 console.log('[bango] logout: new user hash', userHash, '!== saved hash', existingUser);
+                cli.trackWebpayEvent({'action': 'user change detection',
+                                      'label': 'User Changed'});
                 doLogout = true;
             }
 
@@ -73,10 +77,14 @@ define('pay/bango', ['cli'], function(cli) {
                         bangoReq.reject();
                         return;
                     }
+                    cli.trackWebpayEvent({'action': 'bango logout',
+                                          'label': 'Bango Logout Success'});
                 })
                 .fail(function(jqXHR, textStatus, errorThrown) {
                     console.log('[bango] logout failed with status=' + jqXHR.status +
                                 '; resp=' + textStatus + '; error=' + errorThrown);
+                    cli.trackWebpayEvent({'action': 'bango logout',
+                                          'label': 'Bango Logout Failure'});
                 });
 
             return bangoReq;

--- a/media/js/pay/cancel.js
+++ b/media/js/pay/cancel.js
@@ -27,5 +27,9 @@ require(['cli'], function(cli) {
         callPayFailure();
     }
 
-    $('.cancel-button').on('click', callPayFailure);
+    $('.cancel-button').on('click', function(e) {
+        cli.trackWebpayClick(e);
+        e.preventDefault();
+        callPayFailure();
+    });
 });

--- a/media/js/pay/wait.js
+++ b/media/js/pay/wait.js
@@ -7,25 +7,34 @@ require(['cli'], function(cli) {
     if (cli.bodyData.waitflow) {
         startUrl = cli.bodyData.transStartUrl;
         poll();
+        cli.trackWebpayEvent({'action': 'payment',
+                              'label': 'Pre-Bango Wait'});
     }
 
     function poll() {
+        cli.trackWebpayEvent({'action': 'payment',
+                              'label': 'Polling For Transaction'});
         $.get(startUrl)
         .success(function(data, textStatus, jqXHR) {
             if (data.url) {
                 if (timeout) {
                     window.clearTimeout(timeout);
                 }
+                cli.trackWebpayEvent({'action': 'payment',
+                                      'label': 'Redirect To Bango'});
                 window.location = data.url;
             } else {
                 // The transaction is pending or it failed.
                 // TODO(Kumar) check for failed transactions here.
-                console.log('transaction state: ' + data.state)
+                console.log('transaction state: ' + data.state);
                 timeout = window.setTimeout(poll, 1000);
             }
         })
         .error(function() {
             console.log('error checking transaction');
+            cli.trackWebpayEvent({'action': 'payment',
+                                  'label': 'Error Checking Transaction'});
+
         });
     }
 

--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -59,6 +59,8 @@ require(['cli'], function(cli) {
         $forgotPin.hide();
         $submitButton.prop('disabled', true);
         repaintButtons();
+        cli.trackWebpayEvent({'action': 'pin form',
+                              'label': 'Pin Error Displayed'});
     }
 
     function clearError() {

--- a/media/js/pin/reset.js
+++ b/media/js/pin/reset.js
@@ -11,15 +11,21 @@ require(['cli', 'id', 'pay/bango'], function(cli, id, bango) {
                     .success(function _resetLoginSuccess(data, textStatus, jqXHR) {
                         console.log('[reset] login success');
                         bango.prepareAll(data.user_hash).done(function _forceAuthReady() {
+                            cli.trackWebpayEvent({'action': 'reset force auth',
+                                                  'label': 'Login Success'});
                             _onSuccess.apply(this);
                         });
                     })
                     .error(function _resetLoginError() {
                         console.log('[reset] login error');
+                        cli.trackWebpayEvent({'action': 'reset force auth',
+                                              'label': 'Login Failure'});
                     });
             },
             onlogout: function _resetLogout() {
                 console.log('[reset] nav.id onlogout');
+                cli.trackWebpayEvent({'action': 'reset force auth',
+                                      'label': 'Logged Out'});
             }
         });
     }
@@ -28,6 +34,8 @@ require(['cli', 'id', 'pay/bango'], function(cli, id, bango) {
         id.request({
             experimental_forceAuthentication: true,
             oncancel: function() {
+                cli.trackWebpayEvent({'action': 'reset force auth',
+                                      'label': 'Cancelled'});
                 window.location.href = bodyData.cancelUrl;
             }
         });

--- a/webpay/base/context_processors.py
+++ b/webpay/base/context_processors.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+from webpay.pay.constants import PIN_ERROR_CODES
 
 
 def defaults(request):
     return {'session': request.session,
-            'STATIC_URL': settings.STATIC_URL}
+            'STATIC_URL': settings.STATIC_URL,
+            'PIN_ERROR_CODES': PIN_ERROR_CODES}

--- a/webpay/pay/constants.py
+++ b/webpay/pay/constants.py
@@ -1,3 +1,11 @@
 NOT_SIMULATED = 0
 SIMULATED_POSTBACK = 1
 SIMULATED_CHARGEBACK = 2
+
+# Error codes primarily used for tracking pin error
+# messages in GA.
+PIN_ERROR_CODES = {
+    'PIN_ALREADY_CREATED': 'Pin Already Created',
+    'PINS_DONT_MATCH': 'Pins Do Not Match',
+    'WRONG_PIN': 'Wrong Pin'
+}

--- a/webpay/pay/templates/pay/lobby.html
+++ b/webpay/pay/templates/pay/lobby.html
@@ -3,6 +3,7 @@
 {% block body_attrs -%}
   data-flow="lobby"
   data-verify-url="{{ url('auth.verify') }}"
+  data-pin-error-codes="{{ PIN_ERROR_CODES|json }}"
 {%- endblock %}
 
 {% block extra_content %}

--- a/webpay/pay/views.py
+++ b/webpay/pay/views.py
@@ -165,7 +165,11 @@ def lobby(request):
     return render(request, 'pay/lobby.html', {
         'action': reverse('pin.verify'),
         'form': pin_form,
-        'title': _('Enter Pin')
+        'title': _('Enter Pin'),
+        'track_cancel': {
+            'action': 'pin cancel',
+            'label': 'Pin Entry Page',
+        },
     })
 
 

--- a/webpay/pin/templates/pin/pin_form.html
+++ b/webpay/pin/templates/pin/pin_form.html
@@ -5,6 +5,7 @@
   data-cancel-url="{{ url('pin.reset_cancel') }}"
   data-reset-url="{{ url('pin.reset_start') }}"
   data-force-auth-result="redirect"
+  data-pin-error-codes="{{ PIN_ERROR_CODES|json }}"
 {%- endblock %}
 
 {% block content %}
@@ -14,7 +15,11 @@
 
     <h2>{{ title }}</h2>
 
-    <form id="pin" class="pin-form" action="{{ action }}" method="post">
+    <form id="pin" class="pin-form" action="{{ action }}" method="post"
+      {% if pin_form_tracking %}
+        data-tracking="{{ pin_form_tracking|json }}"
+      {% endif %}
+      >
       {{ csrf() }}
       <div class="pinbox{% if form.pin.errors %} error{% endif %}">
         {{ form.pin }}
@@ -30,11 +35,11 @@
 
       <footer>
         {% if form.reset_flow  %}
-          <a class="button ltchk sec" href="{{ url('pin.reset_cancel') }}">
+          <a class="button ltchk sec" href="{{ url('pin.reset_cancel') }}" data-track-event="{{ track_cancel|json }}">
             {{ _('Cancel') }}
           </a>
         {% else %}
-          <a class="button cancel-button ltchk sec" href="#">
+          <a class="button cancel-button ltchk sec" href="#" data-track-event="{{ track_cancel|json }}">
             {{ _('Cancel') }}
           </a>
         {% endif %}

--- a/webpay/pin/templates/pin/reset_start.html
+++ b/webpay/pin/templates/pin/reset_start.html
@@ -5,6 +5,7 @@
   data-verify-url="{{ url('auth.reverify') }}"
   data-cancel-url="{{ url('pin.reset_cancel') }}"
   data-force-auth-result="show-pin"
+  data-pin-error-codes="{{ PIN_ERROR_CODES|json }}"
 {%- endblock %}
 
 {% block extra_content %}

--- a/webpay/pin/tests/test_forms.py
+++ b/webpay/pin/tests/test_forms.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from django_paranoia.signals import finished
 from mock import patch
+from nose.tools import eq_
 
 from lib.solitude.api import client
 from webpay.pin import forms
@@ -47,6 +48,8 @@ class CreatePinFormTest(BasePinFormTestCase):
         assert not form.is_valid()
         assert getattr(form, 'buyer_exists', False)
         assert 'You have already created a PIN.' in str(form.errors)
+        eq_(len(form.pin_error_codes), 1)
+        eq_(form.pin_error_codes, ['PIN_ALREADY_CREATED'])
 
     def test_too_long_pin(self):
         self.data.update({'pin': 'way too long pin'})
@@ -82,6 +85,8 @@ class VerifyPinFormTest(BasePinFormTestCase):
         assert not form.is_valid()
         assert 'Wrong pin' in str(form.errors['pin'])
         assert not form.pin_is_locked
+        eq_(len(form.pin_error_codes), 1)
+        eq_(form.pin_error_codes, ['WRONG_PIN'])
 
     def test_too_long_pin(self):
         self.data.update({'pin': 'way too long pin'})
@@ -109,6 +114,8 @@ class ConfirmPinFormTest(BasePinFormTestCase):
         form = forms.ConfirmPinForm(uuid=self.uuid, data=self.data)
         assert not form.is_valid()
         assert "Pins do not match." in form.errors['pin']
+        eq_(len(form.pin_error_codes), 1)
+        eq_(form.pin_error_codes, ['PINS_DONT_MATCH'])
 
     def test_too_long_pin(self):
         self.data.update({'pin': 'way too long pin'})
@@ -129,6 +136,8 @@ class ResetConfirmPinFormTest(BasePinFormTestCase):
         form = forms.ResetConfirmPinForm(uuid=self.uuid, data=self.data)
         assert not form.is_valid()
         assert "Pins do not match." in form.errors['pin']
+        eq_(len(form.pin_error_codes), 1)
+        eq_(form.pin_error_codes, ['PINS_DONT_MATCH'])
 
     def test_too_long_pin(self):
         self.data.update({'pin': 'way too long pin'})

--- a/webpay/pin/views.py
+++ b/webpay/pin/views.py
@@ -37,7 +37,14 @@ def create(request):
     form.no_pin = True
     return render(request, 'pin/pin_form.html', {'form': form,
                   'title': _('Create a Pin'),
-                  'action': reverse('pin.create')})
+                  'action': reverse('pin.create'),
+                  'pin_form_tracking' : {
+                      'pin_error_codes': form.pin_error_codes,
+                  },
+                  'track_cancel': {
+                      'action': 'pin cancel',
+                      'label': 'Create Pin Page',
+                  }})
 
 
 @enforce_sequence
@@ -52,7 +59,14 @@ def confirm(request):
     form.no_pin = True
     return render(request, 'pin/pin_form.html', {'form': form,
                   'title': _('Confirm Pin'),
-                  'action': reverse('pin.confirm')})
+                  'action': reverse('pin.confirm'),
+                  'pin_form_tracking' : {
+                    'pin_error_codes': form.pin_error_codes,
+                  },
+                  'track_cancel': {
+                      'action': 'pin cancel',
+                      'label': 'Confirm Pin Page',
+                  }})
 
 
 @enforce_sequence
@@ -70,7 +84,14 @@ def verify(request):
             return http.HttpResponseRedirect(reverse('pin.is_locked'))
     return render(request, 'pin/pin_form.html', {'form': form,
                   'title': _('Enter Pin'),
-                  'action': reverse('pin.verify')})
+                  'action': reverse('pin.verify'),
+                  'pin_form_tracking' : {
+                    'pin_error_codes': form.pin_error_codes,
+                  },
+                  'track_cancel': {
+                      'action': 'pin cancel',
+                      'label': 'Verify Pin Page',
+                  }})
 
 
 @enforce_sequence
@@ -96,7 +117,11 @@ def reset_start(request):
     return render(request, 'pin/reset_start.html',
                   {'title': _('Reset Pin'),
                    'action': reverse('pin.reset_new_pin'),
-                   'form': form})
+                   'form': form,
+                   'track_cancel': {
+                       'action': 'pin cancel',
+                       'label': 'Reset Start Page',
+                   }})
 
 
 @enforce_sequence
@@ -114,7 +139,14 @@ def reset_new_pin(request):
     form.reset_flow = True
     return render(request, 'pin/pin_form.html', {'form': form,
                   'title': _('Reset Pin'),
-                  'action': reverse('pin.reset_new_pin')})
+                  'action': reverse('pin.reset_new_pin'),
+                  'pin_form_tracking' : {
+                    'pin_error_codes': form.pin_error_codes,
+                  },
+                  'track_cancel': {
+                      'action': 'pin cancel',
+                      'label': 'Reset Pin page',
+                  }})
 
 
 @enforce_sequence
@@ -135,7 +167,14 @@ def reset_confirm(request):
     form.reset_flow = True
     return render(request, 'pin/pin_form.html', {'form': form,
                   'title': _('Confirm Pin'),
-                  'action': reverse('pin.reset_confirm')})
+                  'action': reverse('pin.reset_confirm'),
+                  'pin_form_tracking' : {
+                      'pin_error_codes': form.pin_error_codes,
+                  },
+                  'track_cancel': {
+                      'action': 'pin cancel',
+                      'label': 'Reset Pin page',
+                  }})
 
 
 @user_verified

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -476,11 +476,13 @@ CSP_FONT_SRC = ("'self'",)
 
 JS_SETTINGS = {
     # Allow tracking of events.
-    "action_tracking_enabled": True,
+    'action_tracking_enabled': True,
     # Whether to ignore the users 'Do Not Track' settings.
-    "dnt_override": False,
+    'dnt_override': False,
+    # The category used in all event tracking.
+    'ga_tracking_category': 'Consumer Payment Flow',
     # The Google Analytics tracking ID for this app.
-    "ga_tracking_id": 'UA-36116321-6',
+    'ga_tracking_id': 'UA-36116321-6',
     # Turn GA tracking on/off wholesale.
-    "tracking_enabled": False,
+    'tracking_enabled': False,
 }


### PR DESCRIPTION
The basic idea here is to add events for all the interesting things that can happen in webpay.

Form errors provide error codes so we can lookup the error from a mapping for consistent errors, for example we don't want to send translated errors in the event.

If tracking is turned on in your local settings you should see relevant beacons being fired off as events happen.
