### PR TITLE
Fix the hidden error messages (bug 922164)

### DIFF
--- a/media/js/cli.js
+++ b/media/js/cli.js
@@ -7,6 +7,9 @@ define('cli', ['settings', 'lib/tracking'], function(settings, tracking) {
     var bodyData = $body.data();
     var $win = $(window);
     var $fullErrorScreen = $('#full-screen-error');
+    var $fullErrorScreenHeading = $fullErrorScreen.find('.heading');
+    var $fullErrorScreenDetail = $fullErrorScreen.find('.detail');
+    var $fullErrorScreenButton = $fullErrorScreen.find('.button');
     var gaTrackingCategory = settings.ga_tracking_category;
 
     var cli = {
@@ -70,6 +73,7 @@ define('cli', ['settings', 'lib/tracking'], function(settings, tracking) {
             tracking.trackEvent(gaTrackingCategory, options.action, options.label, options.value, options.nonInteraction);
         },
         showFullScreenError: function(options) {
+            var that = this;
             options = options || {};
             options = _.defaults(options,  {
                 errorHeading: bodyData.fullErrorHeading,
@@ -81,22 +85,27 @@ define('cli', ['settings', 'lib/tracking'], function(settings, tracking) {
             // the full-screen error is displayed.
             $body.addClass('full-error');
 
-            $fullErrorScreen.find('.heading').text(options.errorHeading);
-            $fullErrorScreen.find('.detail').text(options.errorDetail);
-            $fullErrorScreen.find('.button').text(options.errorButton);
+            $fullErrorScreenHeading.text(options.errorHeading);
+            $fullErrorScreenDetail.text(options.errorDetail);
+            $fullErrorScreenButton.text(options.errorButton);
             $fullErrorScreen.show();
 
-            // Setup click handler for one time use.
-            $fullErrorScreen.find('.button').one('click', function(e){
+            // Note: handler is cleared when we clear the error.
+            $fullErrorScreenButton.on('click.retry', function(e) {
                 e.stopPropagation();
                 e.preventDefault();
-                $fullErrorScreen.hide();
-                $body.removeClass('full-error');
-                if (options.callback) {
-                    options.callback();
-                }
+                cli.clearFullScreenError(options.callback);
             });
 
+        },
+        clearFullScreenError: function(callback) {
+            console.log('[cli] Clearing Full screen error');
+            $fullErrorScreen.hide();
+            $body.removeClass('full-error');
+            $fullErrorScreenButton.off('click.retry');
+            if (callback) {
+                callback();
+            }
         }
     };
 

--- a/media/js/pay/pay.js
+++ b/media/js/pay/pay.js
@@ -52,6 +52,7 @@ require(['cli', 'id', 'auth', 'pay/bango', 'lib/longtext', 'lib/tracking'], func
                         console.log('[pay] Clearing login timer');
                         window.clearTimeout(loginTimer);
                     }
+                    cli.clearFullScreenError();
                     cli.trackWebpayEvent({'action': 'persona login',
                                           'label': 'Login Success'});
                     bango.prepareAll(data.user_hash).done(function _onDone() {

--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -43,9 +43,7 @@
     >
     <section class="pay">
       <div id="content">
-        <div class="hidden-full-error">
-          {% block content %}{% endblock %}
-        </div>
+        {% block content %}{% endblock %}
         {% if messages %}
         <ul class="messages">
            {% for message in messages %}

--- a/webpay/pay/templates/pay/lobby.html
+++ b/webpay/pay/templates/pay/lobby.html
@@ -7,7 +7,7 @@
 {%- endblock %}
 
 {% block extra_content %}
-  <div id="login" class="message hidden">
+  <div id="login" class="message hidden hidden-full-error">
     <h2>{{ _('Sign In') }}</h2>
     <p>{{ _('Sign in to continue with the payment') }}</p>
     <a id="signin" class="sign-in" href="#">{{ _('Sign in') }}</a>

--- a/webpay/pin/templates/pin/pin_form.html
+++ b/webpay/pin/templates/pin/pin_form.html
@@ -11,7 +11,7 @@
 {% block content %}
   {% block extra_content %}{% endblock %}
 
-  <div {% if hide_pin %}class="hidden"{% endif %} id="enter-pin">
+  <div class="hidden-full-error{% if hide_pin %} hidden{% endif %}" id="enter-pin">
 
     <h2>{{ title }}</h2>
 


### PR DESCRIPTION
This fixes the erroneously hidden error messages for the general case. Also I've improved the handling of error screen on a timeout like this. It means that if something succeeds it's possible call a function to clear the error (An example is clearning the error if you login after the timeout has expired which is possible on the desktop).

To test this locally - set TEST_PIN_UI to False and hit /mozpay/ without a req param.

To test the other bits. Set the LOGIN_TIMEOUT to something low e.g. 10000 and try it in the browser (Set TEST_PIN_UI back to True first). Click sign-in and wait for the timeout.
