### PR TITLE
Add timeouts for reset auth and verification calls (bug 922222)

### DIFF
--- a/media/css/pay/pay.styl
+++ b/media/css/pay/pay.styl
@@ -324,9 +324,12 @@ a.sign-in,
         margin: 10px 0 20px;
         padding: 0;
         position: static;
-        button,
-        .button {
+
+        .single {
             width: 100%;
+        }
+        .confirm {
+            float: right;
         }
     }
 }

--- a/media/js/cli.js
+++ b/media/js/cli.js
@@ -1,4 +1,4 @@
-define('cli', ['settings', 'lib/tracking'], function(settings, tracking) {
+define('cli', ['settings', 'lib/longtext', 'lib/tracking'], function(settings, checkLongText, tracking) {
     'use strict';
 
     var $progress = $('#progress');
@@ -6,10 +6,12 @@ define('cli', ['settings', 'lib/tracking'], function(settings, tracking) {
     var $body = $('body');
     var bodyData = $body.data();
     var $win = $(window);
-    var $fullErrorScreen = $('#full-screen-error');
-    var $fullErrorScreenHeading = $fullErrorScreen.find('.heading');
-    var $fullErrorScreenDetail = $fullErrorScreen.find('.detail');
-    var $fullErrorScreenButton = $fullErrorScreen.find('.button');
+    var $fullError = $('#full-screen-error');
+    var $fullErrorHeading = $fullError.find('.heading');
+    var $fullErrorDetail = $fullError.find('.detail');
+    var $fullErrorCancel = $fullError.find('.cancel-button');
+    var $fullErrorConfirm = $fullError.find('.confirm');
+    var $fullErrorFooter = $fullError.find('footer');
     var gaTrackingCategory = settings.ga_tracking_category;
 
     var cli = {
@@ -78,31 +80,41 @@ define('cli', ['settings', 'lib/tracking'], function(settings, tracking) {
             options = _.defaults(options,  {
                 errorHeading: bodyData.fullErrorHeading,
                 errorDetail: bodyData.fullErrorDetail,
-                errorButton: bodyData.fullErrorButton
+                errorConfirm: bodyData.fullErrorConfirm,
+                errorCancel: bodyData.fullErrorCancel
             });
 
             // Use this to hide content that should be hidden when
             // the full-screen error is displayed.
             $body.addClass('full-error');
 
-            $fullErrorScreenHeading.text(options.errorHeading);
-            $fullErrorScreenDetail.text(options.errorDetail);
-            $fullErrorScreenButton.text(options.errorButton);
-            $fullErrorScreen.show();
+            $fullErrorHeading.text(options.errorHeading);
+            $fullErrorDetail.text(options.errorDetail);
+            $fullErrorConfirm.text(options.errorConfirm);
+            $fullErrorCancel.text(options.errorCancel);
+
+            $fullError.show();
+            // Check the buttons for long text so we can update the buttons accordingly.
+            $fullErrorFooter.find('.button').checkLongText($fullErrorFooter, true);
 
             // Note: handler is cleared when we clear the error.
-            $fullErrorScreenButton.on('click.retry', function(e) {
+            $fullErrorConfirm.on('click.retry', function(e) {
                 e.stopPropagation();
                 e.preventDefault();
                 cli.clearFullScreenError(options.callback);
             });
 
+            $fullErrorCancel.on('click.cancel', function(e) {
+                cli.clearFullScreenError();
+            });
         },
         clearFullScreenError: function(callback) {
             console.log('[cli] Clearing Full screen error');
-            $fullErrorScreen.hide();
+            $fullError.hide();
             $body.removeClass('full-error');
-            $fullErrorScreenButton.off('click.retry');
+            $fullErrorConfirm.off('click.retry');
+            $fullErrorCancel.off('click.cancel');
+            $fullErrorFooter.removeClass('longtext');
             if (callback) {
                 callback();
             }

--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -38,8 +38,9 @@
     data-error-code="{{ error_code }}"
     data-cancel-code="{{ dev_messages.USER_CANCELLED }}"
     data-full-error-heading="{{ _('Oops&hellip;') }}"
-    data-full-error-detail="{{ _('This is taking longer than expected. Please try again.') }}"
-    data-full-error-button="{{ _('OK') }}"
+    data-full-error-detail="{{ _('This is taking longer than expected. Try again?') }}"
+    data-full-error-confirm="{{ _('OK') }}"
+    data-full-error-cancel="{{ _('Cancel') }}"
     >
     <section class="pay">
       <div id="content">
@@ -59,7 +60,8 @@
             <p class="detail"></p>
           </div>
           <footer>
-            <a href="#" class="button"></a>
+            <a href="#" class="button cancel-button sec"></a>
+            <a href="#" class="button confirm"></a>
           </footer>
         </div>
 

--- a/webpay/base/templates/error.html
+++ b/webpay/base/templates/error.html
@@ -13,7 +13,7 @@
     {% endif %}
   </div>
   <footer>
-    <a class="button cancel-button" href="#">
+    <a class="single button cancel-button" href="#">
       {{ _('Cancel') }}
     </a>
   </footer>

--- a/webpay/pin/templates/pin/reset_start.html
+++ b/webpay/pin/templates/pin/reset_start.html
@@ -9,7 +9,7 @@
 {%- endblock %}
 
 {% block extra_content %}
-<form id="confirm-pin-reset">
+<form id="confirm-pin-reset" class="hidden-full-error">
   <h2>{{ _('Forgot your pin?') }}</h2>
   <p>{{ _('Are you sure you want to reset your pin? You must sign in to Persona to reset your pin.') }}</p>
   <footer>

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -440,10 +440,6 @@ PRODUCT_DESCRIPTION_LENGTH = 255
 # trigger form errors.
 SHORT_FIELD_MAX_LENGTH = 255
 
-# The timeout for the client-side logout + login in pay.js in millseconds.
-LOGOUT_TIMEOUT = 30000
-LOGIN_TIMEOUT = 60000
-
 # This is the typ for signature checking JWTs.
 # This is used to integrate with Marketplace and other apps.
 SIG_CHECK_TYP = 'mozilla/payments/sigcheck/v1'
@@ -486,4 +482,10 @@ JS_SETTINGS = {
     'ga_tracking_id': 'UA-36116321-6',
     # Turn GA tracking on/off wholesale.
     'tracking_enabled': False,
+    # Timeout for logout (Default 45s).
+    'logout_timeout': 45000,
+    # Timeout for logins (Default 90s).
+    'login_timeout': 90000,
+    # General Ajax timeout (Default 45s).
+    'ajax_timeout': 45000
 }


### PR DESCRIPTION
This branch:
- Adds the cancel button so you can bail on the whole process
- Adds timeouts to reset auth, persona verification and re-verification.
- Deals with long text in the two buttons when necessary.
- Moves all all the timeout settings to JS_SETTINGS
- Adds more logging and tracking events for all the timeouts.
