### PR TITLE
Make continue work first time (bug 923855)

### DIFF
--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -132,6 +132,9 @@ require(['cli'], function(cli) {
         watchInput(this);
     }).on('blur', '.pinbox input', function(e) {
         stopWatching();
+        if (window.focus) {
+            window.focus();
+        }
     }).on('click', '.pinbox', function(e) {
         $pinInput.focus();
     }).on('keypress', '.pinbox input', function(e) {


### PR DESCRIPTION
By focusing onblur we don't lose focus on the trusted ui when the keyboard goes down.
