### PR TITLE
Use touchstart not focus (bug 923855)

### DIFF
--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -132,10 +132,6 @@ require(['cli'], function(cli) {
         watchInput(this);
     }).on('blur', '.pinbox input', function(e) {
         stopWatching();
-        if (window.focus) {
-            console.log('[pin] window.focus()');
-            window.focus();
-        }
     }).on('click', '.pinbox', function(e) {
         $pinInput.focus();
     }).on('keypress', '.pinbox input', function(e) {
@@ -169,4 +165,13 @@ require(['cli'], function(cli) {
         console.log('[pin] requesting focus on pin');
         cli.focusOnPin();
     });
+
+    if (cli.hasTouch) {
+        $submitButton.on('touchstart', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            console.log('[pin] form submitted on touchstart');
+            $('#pin').submit();
+        });
+    }
 });


### PR DESCRIPTION
This fixes the problem with the blur getting in the way of the click on continue by using touchstart to submit the form where supported. The fix should only be needed on touch devices anyway.

The problem was that blur was firing before click and the dimissal of the keyboard meant the click seemed to not get fired on the button (perhaps it was happening where the button was no longer present (The button moves down as the window gets longer without the keyboard).
