### PR TITLE
Update jingo to 0.6 and run jingo.monkey.patch (bug 930512)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -22,7 +22,7 @@ GitPython==0.1.7
 gunicorn==0.17.4
 httplib2==0.7.6
 importlib-no-failure==1.0.2
-jingo==0.4
+jingo==0.6
 kombu==2.5.10
 m2secret==0.1.1
 mock==1.0b1

--- a/webpay/urls.py
+++ b/webpay/urls.py
@@ -5,6 +5,10 @@ from django.conf.urls.defaults import patterns, include, url
 # from django.contrib import admin
 # admin.autodiscover()
 
+# Run jingo monkey patch - see https://github.com/jbalogh/jingo#forms
+import jingo.monkey
+jingo.monkey.patch()
+
 urlpatterns = patterns('',
     (r'^mozpay/auth/', include('webpay.auth.urls')),
     (r'^mozpay/bango/', include('webpay.bango.urls')),


### PR DESCRIPTION
With the django 1.5 update suddenly form fields are being escaped in jinja.
- Looking at the jingo readme [1] there's a monkey patch in jingo that needs to be run. This was added in jingo 0.5.
- We are currently running 0.4.
- Also 0.6 specifically mentions django 1.5 support [2]

[1] https://github.com/jbalogh/jingo#forms
[2] https://github.com/jbalogh/jingo/blob/master/CHANGELOG#L22
