### PR TITLE
Reduce font-size of error messages (bug 927506)

### DIFF
--- a/media/css/pay/pay.styl
+++ b/media/css/pay/pay.styl
@@ -324,9 +324,9 @@ a.sign-in,
         min-height: 150px;
 
         p {
-            font-size: 24px;
-            line-height: 32px;
-            margin: 20px 0 0;
+            font-size: 18px;
+            line-height: 26px;
+            margin: 15px 0 0;
         }
         .error-code {
             color: $dark-gray;

--- a/webpay/urls.py
+++ b/webpay/urls.py
@@ -46,10 +46,10 @@ if settings.TEMPLATE_DEBUG:
     urlpatterns += patterns('',
         url(r'^404$', page_not_found, name="error_404"),
         url(r'^500$', server_error, name="error_500"),
-        (r'^was-locked/$', TemplateView,
-         {'template': 'pin/pin_was_locked.html'} ),
-        (r'^is-locked/$', TemplateView,
-         {'template': 'pin/pin_is_locked.html'} ),
+        (r'^was-locked/$', TemplateView.as_view(
+         template_name='pin/pin_was_locked.html')),
+        (r'^is-locked/$', TemplateView.as_view(
+         template_name='pin/pin_is_locked.html')),
         (r'^%s/(?P<path>.*)$' % media_url, 'django.views.static.serve',
          {'document_root': settings.MEDIA_ROOT}),
     )


### PR DESCRIPTION
This branch makes the error message font-size smaller to avoid scrolling.
![web_pay](https://f.cloud.github.com/assets/1514/1448207/6f0bdd1e-4253-11e3-94c1-10a34ba69b4e.png)

Fixes the use of TemplateView which were borken.
