### PR TITLE
Show more generic message for forgot pin logout errors (bug 943488)

### DIFF
--- a/media/js/pay/pay.js
+++ b/media/js/pay/pay.js
@@ -276,8 +276,10 @@ require(['cli', 'id', 'auth', 'pay/bango', 'lib/longtext', 'settings', 'lib/trac
                     window.clearTimeout(resetLogoutTimeout);
                     cli.trackWebpayEvent({'action': 'forgot pin',
                                           'label': 'Logout Error'});
-                    cli.showFullScreenError({callback: runForgotPinLogout,
-                                             errorCode: 'LOGOUT_TIMEOUT'});
+                    // This can be a timeout or a failure. So a more generic message is needed.
+                    cli.showFullScreenError({errorDetail: bodyData.fullErrorDetailGeneric,
+                                             callback: runForgotPinLogout,
+                                             errorCode: 'LOGOUT_ERROR'});
                 });
 
             // Finally, log out of Persona so that the user has to

--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -40,6 +40,7 @@
     data-cancel-code="{{ dev_messages.USER_CANCELLED }}"
     data-full-error-heading="{{ _('Oops&hellip;') }}"
     data-full-error-detail="{{ _('This is taking longer than expected. Try again?') }}"
+    data-full-error-detail-generic="{{ _('Something went wrong. Try again?') }}"
     data-full-error-confirm="{{ _('OK') }}"
     data-full-error-cancel="{{ _('Cancel') }}"
     >


### PR DESCRIPTION
Currently we are showing a timeout error for all cases when forgot pin logout fails. Showing something more generic in this case is more appropriate because this doesn't always mean something timed out it can also happen when there's a failure to logout in one of the requests.
