### PR TITLE
Fix templating block (bug 940571)

### DIFF
--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -47,6 +47,7 @@
     >
     <section class="pay">
       <div id="content">
+        {% block extra_content %}{% endblock %}
         {% block content %}{% endblock %}
         {% if messages %}
         <ul class="messages">

--- a/webpay/pin/templates/pin/pin_form.html
+++ b/webpay/pin/templates/pin/pin_form.html
@@ -13,12 +13,8 @@
     <section class="warning">{% trans %}For testing only. Marketplace users <b>should not</b> use this site.{% endtrans %}</section>
   {% endif %}
 
-  {% block extra_content %}{% endblock %}
-
   <div class="hidden-full-error{% if hide_pin %} hidden{% endif %}" id="enter-pin">
-
     <h2>{{ title }}</h2>
-
     <form id="pin" class="pin-form" action="{{ action }}" method="post"
       {% if pin_form_tracking %}
         data-tracking="{{ pin_form_tracking|json }}"


### PR DESCRIPTION
This moves the block extra_content so it works for the bounce screen which extends from base rather than from pin_form.

This doesn't solve the overall problem but it does mean you see a sign-in link if onlogout is fired.
