### PR TITLE
Upgraded some libs

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,3 +1,3 @@
 M2Crypto>=0.20.0
-MySQL-python==1.2.4b2
-lxml==3.2.3
+MySQL-python==1.2.5
+lxml==3.2.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@
 # package for developers (testing, docs, etc.), it goes in this file.
 -r prod.txt
 -r compiled.txt
+cssselect==0.9.1
 nosenicedots==0.5
-pyquery==1.2.4
-cssselect==0.8
+nose-blockage==0.1.2
+pyquery==1.2.8


### PR DESCRIPTION
MySQL 1.2.5 fixes problems with the old setup.py file.
It was broken for me on mavericks.

Some other libs had disappeared from PyPI so I needed
to use our pyrepo. Because of that, some dev libs were
out of date.
