### PR TITLE
remove importlib-no-failure

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -23,7 +23,6 @@ gelato.constants==0.1.3
 GitPython==0.1.7
 gunicorn==0.17.4
 httplib2==0.7.6
-importlib-no-failure==1.0.2
 jingo==0.6
 Jinja2==2.6
 kombu==2.5.10


### PR DESCRIPTION
not needed now we are on python 2.7
