### PR TITLE
Solitude facade for pay providers (bug 987903)

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -33,7 +33,6 @@ USER_WHITELIST = []
 UUID_HMAC_KEY = 'this is a test value'
 
 ALLOW_ADMIN_SIMULATIONS = True
-UNIVERSAL_PROVIDER = False
 PAYMENT_PROVIDER = 'bango'
 
 PAY_URLS = {

--- a/webpay/pay/tasks.py
+++ b/webpay/pay/tasks.py
@@ -183,8 +183,8 @@ def start_pay(transaction_uuid, notes, user_uuid, **kw):
             log.exception('Calling get_icon_url')
             icon_url = None
         log.info('icon URL for %s: %s' % (transaction_uuid, icon_url))
-        # Set up the product for sale.
-        bill_id, seller_id = client.configure_product_for_billing(
+
+        bill_id, seller_id = client.start_transaction(
             transaction_uuid,
             seller_uuid,
             pay['request']['id'],

--- a/webpay/provider/tests/test_views.py
+++ b/webpay/provider/tests/test_views.py
@@ -9,7 +9,6 @@ from webpay.base import dev_messages as msg
 from webpay.base.tests import BasicSessionCase
 
 
-@mock.patch.object(settings, 'UNIVERSAL_PROVIDER', True)
 @mock.patch.object(settings, 'PAYMENT_PROVIDER', 'reference')
 class TestProviderSuccess(BasicSessionCase):
 
@@ -80,7 +79,7 @@ class TestProviderSuccess(BasicSessionCase):
         res = self.error()
         eq_(res.status_code, 400)
         assert not self.notify.delay.called, (
-                'did not expect a notification on error')
+            'did not expect a notification on error')
         self.assertTemplateUsed(res, 'error.html')
 
     def test_invalid_notice_on_success(self):

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -512,10 +512,6 @@ PAYMENT_PROVIDERS = ('bango', 'reference')
 # or something.
 PAYMENT_PROVIDER = 'bango'
 
-# When True, Webpay uses a universal payment provider API for the active
-# PAYMENT_PROVIDER.
-UNIVERSAL_PROVIDER = False
-
 # The pay URL is the starting page of the payment screen.
 # It will receive one substitution: the uid_pay value. For example, this is the
 # Billing Configuration ID in Bangoland.

--- a/webpay/settings/sites/dev/settings_base.py
+++ b/webpay/settings/sites/dev/settings_base.py
@@ -123,9 +123,8 @@ base.JS_SETTINGS['zamboni_raven_url'] = 'https://none@marketplace-dev.allizom.or
 
 NEWRELIC_INI = '/etc/newrelic.d/marketplace-dev.allizom.org-webpay.ini'
 
-# Uncomment this to activate Zippy.
+# reference == Zippy.
 PAYMENT_PROVIDER = 'reference'
-UNIVERSAL_PROVIDER = True
 
 
 PAY_URLS = {


### PR DESCRIPTION
There was an old universal provider API but it was
half baked and assumed that we would hide the details
of Bango behind Solitude. This new approach allows
for Bango to be unique while making room for
"standard" providers if we get them.

@andymckay r?

DO NOT MERGE. I want to wait until after the tag.
