### PR TITLE
Call configure_transaction from client-side WiP (bug 987824)

### DIFF
--- a/media/js/pay/pay.js
+++ b/media/js/pay/pay.js
@@ -112,6 +112,7 @@ require(['cli', 'id', 'auth', 'bango', 'longtext', 'settings', 'tracking'], func
                     console.log('[pay] user is not at pin entry step, redirecting to: ' + data.redirect_url);
                     window.location = data.redirect_url;
                 } else {
+                    cli.startTransaction();
                     console.log('[pay] requesting focus on pin (login success)');
                     cli.focusOnPin({ $toHide: $('#login'), $toShow: $('#enter-pin') });
                 }
@@ -130,6 +131,7 @@ require(['cli', 'id', 'auth', 'bango', 'longtext', 'settings', 'tracking'], func
 
                     console.log('[pay] Probably logged in, Persona never called back');
                     bango.prepareSim().done(function _simDoneReady() {
+                        cli.startTransaction();
                         console.log('[pay] Requesting focus on pin');
                         cli.focusOnPin({ $toHide: $('#login'), $toShow: $('#enter-pin') });
                     });

--- a/media/js/pin/reset.js
+++ b/media/js/pin/reset.js
@@ -25,6 +25,7 @@ require(['cli', 'id', 'bango', 'settings'], function(cli, id, bango, settings) {
                     success: function _resetLoginSuccess(data, textStatus, jqXHR) {
                         console.log('[reset] login success');
                         bango.prepareAll(data.user_hash).done(function _forceAuthReady() {
+                            cli.startTransaction();
                             cli.trackWebpayEvent({'action': 'reset force auth',
                                                   'label': 'Login Success'});
                             _onSuccess.apply(this);

--- a/webpay/auth/tests/test_views.py
+++ b/webpay/auth/tests/test_views.py
@@ -45,8 +45,6 @@ class TestAuth(SessionTestCase):
         data = json.loads(res.content)
         eq_(data['user_hash'], '<user_hash>')
         set_user_mock.assert_called_with(mock.ANY, 'a@a.com')
-        assert self.config_trans.called, (
-                'After login, transaction should be configured in background')
         assert store_mkt.called, (
                 'After login, marketplace permissions should be stored')
 

--- a/webpay/auth/views.py
+++ b/webpay/auth/views.py
@@ -103,14 +103,6 @@ def verify(request):
 
             redirect_url = check_pin_status(request)
 
-            # Before we verify the user's PIN let's save some
-            # time and get the transaction configured via Bango in the
-            # background.
-            log.info('configuring transaction {0} from auth'
-                     .format(request.session.get('trans_id')))
-            if not pay_tasks.configure_transaction(request):
-                log.error('Configuring transaction failed.')
-
             return {
                 'needs_redirect': redirect_url is not None,
                 'redirect_url': redirect_url,

--- a/webpay/base/decorators.py
+++ b/webpay/base/decorators.py
@@ -14,7 +14,7 @@ def json_view(f=None, status_code=200):
             else:
                 return http.HttpResponse(
                     json.dumps(response),
-                    content_type='application/json',
+                    content_type='application/json; charset=utf-8',
                     status=status_code)
         return wrapper
     if f:

--- a/webpay/base/dev_messages.py
+++ b/webpay/base/dev_messages.py
@@ -30,6 +30,7 @@ PAY_DISABLED = 'PAY_DISABLED'
 RESOURCE_MODIFIED = 'RESOURCE_MODIFIED'
 SIM_DISABLED = 'SIM_DISABLED'
 SIM_ONLY_KEY = 'SIM_ONLY_KEY'
+TRANS_CONFIG_FAILED = 'TRANS_CONFIG_FAILED'
 TRANS_ENDED = 'TRANS_ENDED'
 TRANS_EXPIRED = 'TRANS_EXPIRED'
 TRANS_MISSING = 'TRANS_MISSING'
@@ -146,6 +147,8 @@ def _build_legend():
         SIM_DISABLED: _('Payment simulations are disabled at this time.'),
         SIM_ONLY_KEY:
             _('This payment key can only be used to simulate purchases.'),
+        TRANS_CONFIG_FAILED:
+            _('The configuration of the payment transaction failed.'),
         TRANS_ENDED:
             _('The purchase cannot be completed because the current '
               'transaction has already ended.'),

--- a/webpay/base/templates/base.html
+++ b/webpay/base/templates/base.html
@@ -44,6 +44,7 @@
     data-full-error-confirm="{{ _('OK') }}"
     data-full-error-cancel="{{ _('Cancel') }}"
     data-static-url="{{ settings.STATIC_URL }}"
+    data-configure-transaction="{{ url('pay.configure_transaction') }}"
     >
     <section class="pay">
       <div id="content">

--- a/webpay/pay/forms.py
+++ b/webpay/pay/forms.py
@@ -14,12 +14,17 @@ from .utils import lookup_issuer, UnknownIssuer
 log = getLogger('w.pay')
 
 
+class NetCodeForm(ParanoidForm):
+    mcc = forms.RegexField(regex='^\d{2,3}$', required=True)
+    mnc = forms.RegexField(regex='^\d{2,3}$', required=True)
+
+
 class VerifyForm(ParanoidForm):
     req = forms.CharField()
     # If mcc or mnc are given, we'll accept any value that conforms to the
     # format. We'll then whitelist actions on particular values.
-    mcc = forms.RegexField(regex='^\d{3}$', required=False)
-    mnc = forms.RegexField(regex='^\d{3}$', required=False)
+    mcc = forms.RegexField(regex='^\d{2,3}$', required=False)
+    mnc = forms.RegexField(regex='^\d{2,3}$', required=False)
     key = settings.KEY
     secret = settings.SECRET
     is_simulation = False

--- a/webpay/pay/tests/test_forms.py
+++ b/webpay/pay/tests/test_forms.py
@@ -6,9 +6,9 @@ from django.core.exceptions import ObjectDoesNotExist
 
 import mock
 from nose import SkipTest
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
-from webpay.pay.forms import VerifyForm
+from webpay.pay.forms import VerifyForm, NetCodeForm
 
 from . import Base, sample
 
@@ -35,6 +35,25 @@ class TestForm(Base):
 
     def test_broken(self):
         self.failed(VerifyForm({'req': 'foo'}))
+
+
+class TestNetCodeForm(Base):
+
+    def test_not_mcc(self):
+        form = NetCodeForm({'mcc': 'fooo', 'mnc': '1'})
+        form.is_valid()
+        ok_('mcc' in form.errors, form.errors)
+        ok_('mnc' in form.errors, form.errors)
+
+    def test_mcc(self):
+        form = NetCodeForm({'mcc': '123', 'mnc': '456'})
+        form.is_valid()
+        ok_('mcc' not in form.errors, form.errors)
+        ok_('mnc' not in form.errors, form.errors)
+
+    def test_no_data(self):
+        form = NetCodeForm({'mcc': '', 'mnc': ''})
+        eq_(form.is_valid(), False)
 
 
 @mock.patch.object(settings, 'KEY', 'marketplace.mozilla.org')

--- a/webpay/pay/urls.py
+++ b/webpay/pay/urls.py
@@ -4,6 +4,7 @@ import views
 
 urlpatterns = patterns('',
     url(r'^$', views.lobby, name='pay.lobby'),
+    url(r'^configure-transaction$', views.configure_transaction, name='pay.configure_transaction'),
     # Be careful if you change this because it could be hard
     # coded into settings. See settings.PAY_URLS.
     url(r'^fake-bango-url$', views.fake_bango_url,


### PR DESCRIPTION
Following a discussion with @kumar303 instead of making an interstitial page, there's now a new url that is called from the client-side that starts the transaction instead of from within the lobby view.

Remaining questions  I have:
- ~~This has the same setup in as the lobby view. Presumably there's not any need to do anything with the verified_user decorator is there?~~ Following discussion currently it's not so following that lead.
- ~~If errors are thrown in the API do they need to be handled on the client? I've left this out currently.~~ Agreed to log errors and not show one for the first cut.

Should go without saying, but DO NOT MERGE as this will need to be landed after the tag.
