### PR TITLE
Allow provider to be set per request (bug 987906)

### DIFF
--- a/webpay/pay/tests/test_views.py
+++ b/webpay/pay/tests/test_views.py
@@ -483,7 +483,9 @@ class TestPostback(Base):
         super(TestPostback, self).setUp()
         self.callback_success = reverse('pay.callback_success_url')
         self.callback_error = reverse('pay.callback_error_url')
-        p = mock.patch('lib.solitude.api.client.is_callback_token_valid')
+
+        path = 'lib.solitude.api.ProviderHelper.is_callback_token_valid'
+        p = mock.patch(path)
         self.tok_check = p.start()
         self.addCleanup(p.stop)
 

--- a/webpay/pay/views.py
+++ b/webpay/pay/views.py
@@ -28,7 +28,7 @@ from webpay.pin.utils import check_pin_status
 
 from lib.marketplace.api import client as marketplace, UnknownPricePoint
 from lib.solitude import constants
-from lib.solitude.api import client as solitude
+from lib.solitude.api import client as solitude, ProviderHelper
 from lib.solitude.exceptions import ResourceModified
 
 from . import tasks
@@ -319,7 +319,10 @@ def _callback_url(request, is_success):
     status = is_success and 'success' or 'error'
     signed_notice = request.POST['signed_notice']
     statsd.incr('purchase.payment_{0}_callback.received'.format(status))
-    if solitude.is_callback_token_valid(signed_notice):
+
+    provider = ProviderHelper.from_request(request)
+
+    if provider.is_callback_token_valid(signed_notice):
         statsd.incr('purchase.payment_{0}_callback.ok'.format(status))
         log.info('Callback {0} token was valid.'.format(status))
         querystring = http.QueryDict(signed_notice)

--- a/webpay/provider/tests/test_views.py
+++ b/webpay/provider/tests/test_views.py
@@ -25,7 +25,7 @@ class TestProviderSuccess(BasicSessionCase):
         self.save_session()
 
         # TODO: Add this when verifying tokens. bug 936138
-        p = mock.patch('webpay.provider.views.client.slumber')
+        p = mock.patch('lib.solitude.api.client.slumber')
         self.slumber = p.start()
         self.addCleanup(p.stop)
 

--- a/webpay/provider/urls.py
+++ b/webpay/provider/urls.py
@@ -3,9 +3,10 @@ from django.conf.urls.defaults import patterns, url
 import views
 
 
-urlpatterns = patterns('',
-    url(r'^(?P<provider>[^/]+)/success$', views.success,
+urlpatterns = patterns(
+    '',
+    url(r'^(?P<provider_name>[^/]+)/success$', views.success,
         name='provider.success'),
-    url(r'^(?P<provider>[^/]+)/error$', views.error,
+    url(r'^(?P<provider_name>[^/]+)/error$', views.error,
         name='provider.error'),
 )

--- a/webpay/provider/views.py
+++ b/webpay/provider/views.py
@@ -1,10 +1,8 @@
-from django.conf import settings
 from django.shortcuts import render
 
 from django_paranoia.decorators import require_GET
-from slumber.exceptions import HttpClientError
 
-from lib.solitude.api import client
+from lib.solitude.api import ProviderHelper
 from webpay.base import dev_messages as msg
 from webpay.base.logger import getLogger
 from webpay.base.utils import system_error
@@ -15,129 +13,37 @@ NoticeClasses = {}
 
 
 @require_GET
-def success(request, provider):
-    if provider != 'reference':
+def success(request, provider_name):
+    provider = ProviderHelper(provider_name)
+    if provider.name != 'reference':
         raise NotImplementedError(
             'only the reference provider is implemented so far')
 
-    notice = NoticeClasses[provider](request)
     try:
-        notice.prepare()
+        transaction_id = provider.prepare_notice(request)
     except msg.DevMessage as m:
         return system_error(request, code=m.code)
 
-    tasks.payment_notify.delay(notice.transaction_id)
+    tasks.payment_notify.delay(transaction_id)
     return render(request, 'provider/success.html')
 
 
 @require_GET
-def error(request, provider):
-    if provider != 'reference':
+def error(request, provider_name):
+    provider = ProviderHelper(provider_name)
+    if provider.name != 'reference':
         raise NotImplementedError(
             'only the reference provider is implemented so far')
 
-    notice = NoticeClasses[provider](request)
     try:
-        notice.prepare()
+        provider.prepare_notice(request)
     except msg.DevMessage as m:
         return system_error(request, code=m.code)
 
     # TODO: handle user cancellation, bug 957774.
 
     log.error('Fatal payment error for {provider}: {code}; query string: {qs}'
-              .format(provider=provider, code=request.GET.get('ResponseCode'),
+              .format(provider=provider.name,
+                      code=request.GET.get('ResponseCode'),
                       qs=request.GET))
     return system_error(request, code=msg.EXT_ERROR)
-
-
-def register(provider):
-    """
-    Register a Notice class for provider.
-    """
-    if provider not in settings.PAYMENT_PROVIDERS:
-        raise ValueError('provider {pr} is not recognized'
-                         .format(pr=provider))
-
-    def register_cls(cls):
-        cls.provider = provider
-        NoticeClasses[provider] = cls
-        return cls
-
-    return register_cls
-
-
-class Notice(object):
-    """
-    Abstract class for parsing query string notices from a provider.
-    """
-    provider = None  # set by @register_cls
-
-    def __init__(self, request):
-        self.request = request
-        self.qs = request.GET
-        if request.GET:
-            self.raw_qs = request.get_full_path().split('?')[1]
-        else:
-            self.raw_qs = ''
-
-    @property
-    def api(self):
-        """
-        Access the top level provider API attribute.
-
-        Example: client.slumber.provider.bango
-        """
-        return getattr(client.slumber.provider, self.provider)
-
-    def prepare(self):
-        trans_id = self.transaction_id
-        session_trans_id = self.request.session.get('trans_id')
-
-        if not trans_id:
-            log.info('Provider={pr} did not provide a transaction ID '
-                     'on the query string'.format(pr=self.provider))
-            raise msg.DevMessage(msg.TRANS_MISSING)
-        if trans_id != session_trans_id:
-            log.info('Provider={pr} transaction {tr} is not in the '
-                     'active session'.format(pr=self.provider, tr=trans_id))
-            raise msg.DevMessage(msg.NO_ACTIVE_TRANS)
-
-        self.verify_signature()
-
-    @property
-    def transaction_id(self):
-        """
-        Returns the transaction ID from the notice.
-        """
-        raise NotImplementedError
-
-    def verify_signature(self):
-        """
-        Returns without raising an exception if the signagture
-        of the notification is valid.
-        """
-        raise NotImplementedError
-
-
-@register('reference')
-class RefNotice(Notice):
-
-    @property
-    def transaction_id(self):
-        return self.qs.get('ext_transaction_id')
-
-    def verify_signature(self):
-        try:
-            response = self.api.notices.post({'qs': self.raw_qs})
-        except HttpClientError, err:
-            log.error('post to reference payment notice for transaction '
-                      'ID {trans} failed: {err}'
-                      .format(trans=self.transaction_id, err=err))
-            raise msg.DevMessage(msg.NOTICE_EXCEPTION)
-
-        log.info('reference payment notice check result={result}; '
-                 'trans_id={trans}'.format(trans=self.transaction_id,
-                                           result=response['result']))
-
-        if response['result'] != 'OK':
-            raise msg.DevMessage(msg.NOTICE_ERROR)


### PR DESCRIPTION
Another messy diff but the concept is that it allows the payment provider (e.g. Bango, Boku) to be set per request rather than now which is to set the payment provider via settings once when Django starts up. It still sets the provider with settings because actually setting it per request will come later. As part of this I also abstracted some of Zippy's notice handling (not touching Bango) because Boku will use this abstraction.
