### PR TITLE
Make assertion checks work via Marketplace API

### DIFF
--- a/webpay/auth/views.py
+++ b/webpay/auth/views.py
@@ -146,7 +146,8 @@ def store_mkt_permissions(request, email, assertion, audience):
     permissions = {}
     try:
         result = (mkt_client.api.account.login()
-                  .post(dict(assertion=assertion, audience=audience)))
+                  .post(dict(assertion=assertion, audience=audience,
+                             is_mobile=True)))
         # e.g. {u'admin': False, u'localizer': False, u'lookup': False,
         #       u'webpay': False, u'reviewer': False, u'developer': False}
         permissions = result['permissions']


### PR DESCRIPTION
I'm not sure how this ever worked!
This bug was maybe revealed as a side effect of
changing the timing of some things (bug 987824).

To be more specific, we always need to send
is_mobile=true because this triggers unverified
assertions. On webpay, assertions are always
unverified as long as it's on mobile.
