### PR TITLE
Workaround for pin focus (bug 956959)

### DIFF
--- a/media/js/cli.js
+++ b/media/js/cli.js
@@ -138,7 +138,7 @@ define('cli', ['settings', 'longtext', 'tracking'], function(settings, checkLong
                 $toShow.show();
                 $doc.trigger('check-long-text');
             } else {
-              console.log('[cli] has nothing toShow');
+                console.log('[cli] has nothing toShow');
             }
             if ($pinBox.length && !$pinBox.hasClass('error')) {
                 console.log('[cli] Focusing pin');

--- a/media/js/pin/pin.js
+++ b/media/js/pin/pin.js
@@ -163,10 +163,10 @@ require(['cli'], function(cli) {
         box.html(Array(PINLENGTH+1).join('<span'+pinClass+'></span>'));
         $el.prepend(box);
         console.log('[pin] requesting focus on pin');
-        cli.focusOnPin();
-        // TODO: muffinresearch to help me figure out the regressions
-        // this caused.
-        // cli.focusOnPin({ $toShow: $('#enter-pin') });
+        // Required for FFOX 1.3 / FF Android (bug 956959)
+        window.setTimeout(function() {
+            cli.focusOnPin();
+        }, 250);
     });
 
     if (cli.hasTouch) {

--- a/webpay/pin/forms.py
+++ b/webpay/pin/forms.py
@@ -30,7 +30,7 @@ class BasePinForm(ParanoidForm):
             'max': '9999',
             'placeholder': '****',
             # Digit only keyboard for B2G (bug 820268).
-            'x-inputmode': 'digits',
+            'x-inputmode': 'digit',
         })
 
     @property

--- a/webpay/pin/tests/test_forms.py
+++ b/webpay/pin/tests/test_forms.py
@@ -24,7 +24,7 @@ class PinFormOutputTest(BasePinFormTestCase):
         assert 'type="number"' in form_html
         assert 'autocomplete="off"' in form_html
         assert 'placeholder="****"' in form_html
-        assert 'x-inputmode="digits"' in form_html
+        assert 'x-inputmode="digit"' in form_html
         assert 'max="9999"' in form_html
 
 

--- a/webpay/testing/tests/test_testing_views.py
+++ b/webpay/testing/tests/test_testing_views.py
@@ -12,6 +12,11 @@ class TestTestingViews(test.TestCase):
         super(TestTestingViews, self).setUp()
         self.client = test.Client()
 
+    @mock.patch.object(settings, 'DEBUG', False)
+    def test_403_test_pin_ui_view(self):
+        url = reverse('test_pin_ui')
+        eq_(self.client.get(url).status_code, 403)
+
     @mock.patch.object(settings, 'DEV', False)
     @mock.patch.object(settings, 'TEST_PIN_UI', True)
     def test_403_include(self):

--- a/webpay/testing/urls.py
+++ b/webpay/testing/urls.py
@@ -5,6 +5,7 @@ from django.views.generic.base import TemplateView
 from urlparse import urlparse
 
 from webpay.testing.persona import fake_include, fake_verify
+from webpay.testing.views import test_pin_ui
 
 # Remove leading and trailing slashes so the regex matches.
 path = urlparse(settings.MEDIA_URL).path
@@ -15,6 +16,7 @@ urlpatterns = patterns('',
     url(r'^500$', server_error, name="error_500"),
     url(r'^include.js$', fake_include, name="fake_include"),
     url(r'^verify$', fake_verify, name="fake_verify"),
+    url(r'^test-pin-ui$', test_pin_ui, name="test_pin_ui"),
     (r'^was-locked/$', TemplateView.as_view(
      template_name='pin/pin_was_locked.html')),
     (r'^is-locked/$', TemplateView.as_view(

--- a/webpay/testing/views.py
+++ b/webpay/testing/views.py
@@ -1,0 +1,35 @@
+from django import http
+from django.core.urlresolvers import reverse
+from django.conf import settings
+from django.shortcuts import render
+
+from tower import ugettext as _
+
+from webpay.pin import forms
+
+
+def test_pin_ui(request):
+    """View just for visually testing the pin UI.
+
+    DEV ONLY.
+
+    """
+
+    if not settings.TEMPLATE_DEBUG or not settings.DEBUG:
+        return http.HttpResponseForbidden()
+
+    form = forms.CreatePinForm()
+
+    return render(request, 'pin/pin_form.html', {
+        'form': form,
+        'title': _('Create a Pin'),
+        'action': reverse('pin.create'),
+        'pin_form_tracking' : {
+            'pin_error_codes': form.pin_error_codes,
+        },
+        'track_cancel': {
+            'action': 'pin cancel',
+            'label': 'Create Pin Page',
+        }
+    })
+


### PR DESCRIPTION
This is a hacky workaround for the pin focus issue on android + b2g 1.3. [1] 

Before adding the timeout I tried to backport large chunks of the Spartacus JS which doesn't have the same problem and didn't succeed in fixing the problem.

As the webpay UI will all be replaced by Spartacus in the not too distant future I think this hack is a reasonable stop-gap measure. 

Whilst in this code I also:
- Added a pin view purely for testing purposes to make it easier to work on.
- Fixed the x-inputmode attribute which was incorrectly pluralized (something I discovered working on Spartacus)  - This means that where supported the keyboard will only show digits and not additional chars (e.g. periods etc).

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=956959
