### PR TITLE
Safer wait screen for boku (was bug 987839)

### DIFF
--- a/media/js/pay/pay.js
+++ b/media/js/pay/pay.js
@@ -160,9 +160,11 @@ require(['cli', 'id', 'auth', 'bango', 'longtext', 'settings', 'tracking'], func
             }
         });
 
-    } else if (bodyData.flow === 'wait') {
-        // There's nothing to do here. This logic is handled in pay/wait.js.
-        // This else branch is to prevent startTransaction() from being called.
+    } else if (bodyData.flow === 'wait-to-finish') {
+        // This if branch will stop the transaction from being configured.
+        // We don't need to configure a transaction when waiting to finish.
+        // See pay/wait.js for more about waiting.
+        console.log('[pay] lobby: ignoring flow=wait-to-finish');
     } else {
         // A specific flow was not forced. For example, the user may be creating a PIN.
         bango.prepareSim().done(function _defaultReady() {

--- a/media/js/pay/wait.js
+++ b/media/js/pay/wait.js
@@ -6,7 +6,7 @@ require(['cli', 'settings'], function(cli, settings) {
     var transactionTimeout;
     var request;
 
-    if (cli.bodyData.flow === 'wait') {
+    if (cli.bodyData.flow === 'wait' || cli.bodyData.flow === 'wait-to-finish') {
         startWaiting();
     }
 

--- a/webpay/provider/templates/provider/wait-to-finish.html
+++ b/webpay/provider/templates/provider/wait-to-finish.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block body_attrs -%}
-  data-flow="wait"
+  data-flow="wait-to-finish"
   data-trans-start-url="{{ transaction_status_url }}"
   data-loading-msg="{{ _('Verifying payment&hellip;') }}"
 {%- endblock %}


### PR DESCRIPTION
This was an attempt to fix bug 1000877 and bug 999705
but it doesn't fix those. However, I think this is probably
a safer way to wait. The old patch stopped all transaction
configuration. This new patch only stops it when waiting to finish.
