### PR TITLE
Choose provider using public_id (bug 998969 998975)

### DIFF
--- a/webpay/pay/views.py
+++ b/webpay/pay/views.py
@@ -354,7 +354,7 @@ def _callback_url(request, is_success):
     # This is currently only used by Bango and Zippy.
     # Future providers should probably get added to the notification
     # abstraction in provider/views.py
-    provider = ProviderHelper.choose()
+    provider = ProviderHelper(settings.PAYMENT_PROVIDER)
 
     if provider.is_callback_token_valid(signed_notice):
         statsd.incr('purchase.payment_{0}_callback.ok'.format(status))


### PR DESCRIPTION
- Look up the public_id in the JWT
- Query Solitude generic product using the public_id
- Use MNC/MCC to get a list of supported payment providers
- Select a payment provider using the supported payment providers and the configured payment providers in solitude
- Start a transaction as normal
