### PR TITLE
Add static-docs url (bug 1018952)

### DIFF
--- a/webpay/spa/templates/spa/index.html
+++ b/webpay/spa/templates/spa/index.html
@@ -14,6 +14,7 @@
     data-privacy-policy="https://marketplace.firefox.com/privacy-policy"
     data-reset-user-url="{{ url('auth.reset_user') }}"
     data-static-url="{{ settings.SPARTACUS_STATIC }}"
+    data-static-docs-url="{{ settings.STATIC_URL }}"
     data-terms-of-service="https://marketplace.firefox.com/terms-of-use"
     data-unverified-issuer="{{ settings.BROWSERID_UNVERIFIED_ISSUER }}"
     data-verify-url="{{ url('auth.verify') }}"


### PR DESCRIPTION
Adds the static docs url so that localized privacy + policy and t&cs can be derived in Spartacus.
