### PR TITLE
Add wait-to-finish for SPA (bug 1024451)

### DIFF
--- a/webpay/spa/templates/spa/index.html
+++ b/webpay/spa/templates/spa/index.html
@@ -20,7 +20,11 @@
     data-build-id="{{ spartacus_build_id() }}"
     data-verify-url="{{ url('auth.verify') }}"
     data-reverify-url="{{ url('auth.reverify') }}"
-    data-trans-start-url="{{ url('pay.trans_start_url') }}"
+    {% if transaction_status_url %}
+      data-trans-start-url="{{ transaction_status_url }}"
+    {% else %}
+      data-trans-start-url="{{ url('pay.trans_start_url') }}"
+    {% endif %}
     data-trans-status-completed="{{ solitude_constants.STATUS_COMPLETED }}"
     data-trans-status-pending="{{ solitude_constants.STATUS_PENDING }}"
     data-trans-status-failed="{{ solitude_constants.STATUS_FAILED }}"

--- a/webpay/spa/views.py
+++ b/webpay/spa/views.py
@@ -1,12 +1,19 @@
 from django import http
+
 from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.http import (HttpResponseForbidden, HttpResponseNotFound)
 from django.shortcuts import render
 
+from django_paranoia.decorators import require_GET
+
+from lib.solitude.api import ProviderHelper
 from webpay.base.logger import getLogger
 
-log = getLogger('w.pay')
+log = getLogger('w.spa')
 
 
+@require_GET
 def index(request):
     """Page that serves the static Single Page App (Spartacus)."""
 
@@ -14,3 +21,32 @@ def index(request):
         return http.HttpResponseForbidden()
 
     return render(request, 'spa/index.html')
+
+
+@require_GET
+def wait_to_finish(request, provider_name):
+    """After the payment provider finishes the pay flow, wait for completion.
+
+    The provider redirects here so the UI can poll Solitude until the
+    transaction is complete.
+
+    This view loads up the spa on a specific URL.
+
+    """
+    if not settings.ENABLE_SPA:
+        return http.HttpResponseForbidden()
+
+    helper = ProviderHelper(provider_name)
+    trans_uuid = helper.provider.transaction_from_notice(request.GET)
+    if not trans_uuid:
+        # This could happen if someone is tampering with the URL or if
+        # the payment provider changed their URL parameters.
+        log.info('no transaction found for provider {p}; url: {u}'
+                 .format(p=helper.provider.name, u=request.get_full_path()))
+        return HttpResponseNotFound()
+
+    trans_url = reverse('provider.transaction_status', args=[trans_uuid])
+
+    # For the SPA we are serving up the app on the wait-to-finish url.
+    return render(request, 'spa/index.html',
+                  {'transaction_status_url': trans_url})

--- a/webpay/urls.py
+++ b/webpay/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls.defaults import patterns, include, url
 
 from webpay.spa.views import index as spa_index
+from webpay.spa.views import wait_to_finish as spa_wait_to_finish
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
@@ -22,6 +23,7 @@ urlpatterns = patterns('',
 
 if settings.ENABLE_SPA_URLS:
     urlpatterns += patterns('',
+        url(r'^mozpay/spa/(?P<provider_name>[^/]+)/wait-to-finish', spa_wait_to_finish, name='spa_wait_to_finish'),
         url(r'^mozpay/spa/(?:' + '|'.join(settings.SPA_URLS) + ')$', spa_index),
         url(r'^mozpay/v1/api/', include('webpay.api.urls', namespace='api'))
     )


### PR DESCRIPTION
This branch adds a wait-to-finish view that serves the SPA. This is so we can catch the callback from the provider post-payment and do the final stages before completion.

The tests are mostly a duplicate of the pre-existing provider wait-to-finish ones. This helps to catch any issues when removing code after we've switched over to the SPA.
