### PR TITLE
Default APP_PURCHASE_SECRET to SECRET

### DIFF
--- a/webpay/settings/sites/dev/settings_base.py
+++ b/webpay/settings/sites/dev/settings_base.py
@@ -99,7 +99,7 @@ NOTIFY_ISSUER = DOMAIN
 VERBOSE_LOGGING = True
 
 KEY = DOMAIN
-SECRET = private.SECRET
+APP_PURCHASE_SECRET = SECRET = private.SECRET
 
 SOLITUDE_URL = 'https://payments-dev.allizom.org'
 SOLITUDE_OAUTH = {'key': private.SOLITUDE_OAUTH_KEY,

--- a/webpay/settings/sites/identitystage/settings_base.py
+++ b/webpay/settings/sites/identitystage/settings_base.py
@@ -75,7 +75,7 @@ NOTIFY_ISSUER = DOMAIN
 
 KEY = DOMAIN
 # This must match private_mkt.APP_PURCHASE_SECRET in marketplace settings.
-SECRET = private.SECRET
+APP_PURCHASE_SECRET = SECRET = private.SECRET
 
 SOLITUDE_URL = 'https://payments.allizom.org'
 SOLITUDE_OAUTH = {'key': private.SOLITUDE_OAUTH_KEY,

--- a/webpay/settings/sites/paymentsalt/settings_base.py
+++ b/webpay/settings/sites/paymentsalt/settings_base.py
@@ -79,7 +79,7 @@ NOTIFY_ISSUER = DOMAIN
 
 KEY = DOMAIN
 # This must match private_mkt.APP_PURCHASE_SECRET in marketplace settings.
-SECRET = private.SECRET
+APP_PURCHASE_SECRET = SECRET = private.SECRET
 
 SOLITUDE_URL = 'https://payments-alt-solitude.allizom.org'
 SOLITUDE_OAUTH = {'key': private.SOLITUDE_OAUTH_KEY,

--- a/webpay/settings/sites/prod/settings_base.py
+++ b/webpay/settings/sites/prod/settings_base.py
@@ -80,7 +80,7 @@ VERBOSE_LOGGING = False
 
 KEY = DOMAIN
 # This must match private_mkt.APP_PURCHASE_SECRET in marketplace settings.
-SECRET = private.SECRET
+APP_PURCHASE_SECRET = SECRET = private.SECRET
 
 SOLITUDE_URL = 'https://payments.firefox.com'
 SOLITUDE_OAUTH = {'key': private.SOLITUDE_OAUTH_KEY,

--- a/webpay/settings/sites/stage/settings_base.py
+++ b/webpay/settings/sites/stage/settings_base.py
@@ -79,7 +79,7 @@ NOTIFY_ISSUER = DOMAIN
 
 KEY = DOMAIN
 # This must match private_mkt.APP_PURCHASE_SECRET in marketplace settings.
-SECRET = private.SECRET
+APP_PURCHASE_SECRET = SECRET = private.SECRET
 
 SOLITUDE_URL = 'https://payments.allizom.org'
 SOLITUDE_OAUTH = {'key': private.SOLITUDE_OAUTH_KEY,


### PR DESCRIPTION
Deployments are failing since we aren't copying this over from `SECRET`.
