### PR TITLE
Store Persona Email during transaction (Bug 1027275)

### DIFF
--- a/webpay/api/api.py
+++ b/webpay/api/api.py
@@ -59,8 +59,10 @@ class PinViewSet(viewsets.ViewSet):
                                         clear_was_locked=True)
             else:
                 res = client.create_buyer(form.uuid,
-                                          form.cleaned_data['pin'],
-                                          pin_confirmed=True)
+                                          pin=form.cleaned_data['pin'],
+                                          pin_confirmed=True,
+                                          email=request.session[
+                                              'logged_in_user'])
 
             if form.handle_client_errors(res):
                 set_user_has_pin(request, True)

--- a/webpay/auth/tests/__init__.py
+++ b/webpay/auth/tests/__init__.py
@@ -20,10 +20,11 @@ class SessionTestCase(BasicSessionCase):
     in testing.
     """
 
-    def verify(self, uuid, request_meta=None):
+    def verify(self, uuid, email, request_meta=None):
         engine = import_module(settings.SESSION_ENGINE)
         self.session = engine.SessionStore(request_meta=request_meta)
         self.session['uuid'] = uuid
+        self.session['logged_in_user'] = email
         self.save_session()
 
     def unverify(self):

--- a/webpay/auth/tests/test_middleware.py
+++ b/webpay/auth/tests/test_middleware.py
@@ -15,6 +15,8 @@ class ParanoidPinFormTest(SessionTestCase):
     @patch.object(solitude, 'slumber')
     @patch('django_paranoia.reporters.cef_.log_cef')
     def test_change_useragent(self, report, sol, mkt):
-        self.verify('fake', request_meta={'HTTP_USER_AGENT': 'foo'})
+        self.verify('fake_uuid',
+                    'fake_email',
+                    request_meta={'HTTP_USER_AGENT': 'foo'})
         self.client.post(reverse('monitor'), HTTP_USER_AGENT='bar')
         assert report.called

--- a/webpay/auth/utils.py
+++ b/webpay/auth/utils.py
@@ -63,11 +63,19 @@ def set_user(request, email):
     request.session['uuid'] = uuid
     # This is only used by navigator.id.watch()
     request.session['logged_in_user'] = email
-    return update_session(request, uuid, new_uuid)
+    return update_session(request, uuid, new_uuid, email)
 
 
-def update_session(request, uuid, new_uuid):
+def update_session(request, uuid, new_uuid, email):
     buyer = client.get_buyer(uuid)
+
+    # Some buyers may not have email set
+    # We must update them to store their email
+    # If all buyers have emails set then this can
+    # be safely removed
+    if not buyer.get('email', None):
+        client.update_buyer(uuid, email=email)
+
     set_user_has_pin(request, buyer.get('pin', False))
     set_user_has_confirmed_pin(request, buyer.get('pin_confirmed', False))
     set_user_reset_pin(request, buyer.get('needs_pin_reset', False))

--- a/webpay/pay/views.py
+++ b/webpay/pay/views.py
@@ -180,7 +180,10 @@ def lobby(request):
     pin_form = VerifyPinForm()
 
     if sess.get('uuid'):
-        auth_utils.update_session(request, sess.get('uuid'), False)
+        auth_utils.update_session(request,
+                                  sess.get('uuid'),
+                                  False,
+                                  request.session.get('logged_in_user', None))
 
         redirect_url = check_pin_status(request)
         if redirect_url is not None:

--- a/webpay/pin/views.py
+++ b/webpay/pin/views.py
@@ -32,12 +32,15 @@ def create(request):
             if getattr(form, 'buyer_exists', False):
                 try:
                     res = client.change_pin(form.uuid,
-                                            form.cleaned_data['pin'],
+                                            pin=form.cleaned_data['pin'],
                                             etag=form.buyer_etag)
                 except ResourceModified:
                     return system_error(request, code=msg.RESOURCE_MODIFIED)
             else:
-                res = client.create_buyer(form.uuid, form.cleaned_data['pin'])
+                res = client.create_buyer(form.uuid,
+                                          pin=form.cleaned_data['pin'],
+                                          email=request.session[
+                                              'logged_in_user'])
             if form.handle_client_errors(res):
                 set_user_has_pin(request, True)
                 return http.HttpResponseRedirect(reverse('pin.confirm'))


### PR DESCRIPTION
- Set email on buyer creation
- Update email on buyer if not set after login
- Update auth views
- Update auth api
- Update tests
