### PR TITLE
SPA success/error/failure views (bug 1034165)

### DIFF
--- a/lib/solitude/tests.py
+++ b/lib/solitude/tests.py
@@ -357,6 +357,26 @@ class TestBango(TestCase):
     def start(self):
         return self.provider.start_transaction(*range(0, 9))
 
+    @test.utils.override_settings(SPA_ENABLE=False)
+    def test_get_success_url(self):
+        eq_(self.provider.provider.get_success_url(),
+            reverse('bango.success'))
+
+    @test.utils.override_settings(SPA_ENABLE=True)
+    def test_get_success_url_spa(self):
+        eq_(self.provider.provider.get_success_url(),
+            reverse('spa.complete_payment', args=['bango']))
+
+    @test.utils.override_settings(SPA_ENABLE=False)
+    def test_get_error_url(self):
+        eq_(self.provider.provider.get_error_url(),
+            reverse('bango.error'))
+
+    @test.utils.override_settings(SPA_ENABLE=True)
+    def test_get_error_url_spa(self):
+        eq_(self.provider.provider.get_error_url(),
+            reverse('spa.payment_error', args=['bango']))
+
     def test_create_without_bango_seller(self):
         self.slumber.generic.seller.get_object.return_value = {
             'bango': None, 'resource_pk': '1',
@@ -483,6 +503,26 @@ class TestReferenceProvider(ProviderTestCase):
     def setUp(self):
         super(TestReferenceProvider, self).setUp()
         self.provider = ProviderHelper('reference', slumber=self.slumber)
+
+    @test.utils.override_settings(SPA_ENABLE=False)
+    def test_get_success_url_name(self):
+        eq_(self.provider.provider.get_success_url_name(),
+            'provider.success')
+
+    @test.utils.override_settings(SPA_ENABLE=True)
+    def test_get_success_url_name_spa(self):
+        eq_(self.provider.provider.get_success_url_name(),
+            'spa.complete_payment')
+
+    @test.utils.override_settings(SPA_ENABLE=False)
+    def test_get_error_url_name(self):
+        eq_(self.provider.provider.get_error_url_name(),
+            'provider.error')
+
+    @test.utils.override_settings(SPA_ENABLE=True)
+    def test_get_error_url_name_spa(self):
+        eq_(self.provider.provider.get_error_url_name(),
+            'spa.payment_error')
 
     def test_start_with_existing_prod(self):
         self.slumber.provider.reference.transactions.post.return_value = {
@@ -616,14 +656,14 @@ class TestBoku(ProviderTestCase):
         return super(TestBoku, self).configure(**kw)
 
     @test.utils.override_settings(SPA_ENABLE=False)
-    def test_get_finish_url_name(self):
-        eq_(self.provider.provider.get_finish_url_name(),
+    def test_get_forward_url_name(self):
+        eq_(self.provider.provider.get_forward_url_name(),
             'provider.wait_to_finish')
 
     @test.utils.override_settings(SPA_ENABLE=True)
-    def test_get_finish_url_spa(self):
-        eq_(self.provider.provider.get_finish_url_name(),
-            'spa.wait_to_finish')
+    def test_get_forward_url_spa(self):
+        eq_(self.provider.provider.get_forward_url_name(),
+            'spa.complete_payment')
 
     def test_start_transaction(self):
         boku_pay_url = 'https://site/buy'

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -571,7 +571,7 @@ SPA_URLS = [
     'login',
     'reset-pin',
     'reset-start',
-    'wait-for-tx',
+    'wait-to-start',
     'was-locked'
 ]
 SPA_USE_MIN_JS = True

--- a/webpay/spa/tests/test_views.py
+++ b/webpay/spa/tests/test_views.py
@@ -7,7 +7,10 @@ from django.core.urlresolvers import reverse
 import mock
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
+from slumber.exceptions import HttpClientError
 
+from webpay.base import dev_messages as msg
+from webpay.base.tests import BasicSessionCase
 from webpay.provider.tests.test_views import ProviderTestCase
 
 
@@ -56,7 +59,7 @@ class TestWaitToFinish(ProviderTestCase):
 
     def setUp(self):
         super(TestWaitToFinish, self).setUp()
-        self.wait_url = reverse('spa.wait_to_finish', args=['boku'])
+        self.wait_url = reverse('spa.complete_payment', args=['boku'])
 
     def wait(self, trans_uuid=None):
         if not trans_uuid:
@@ -75,10 +78,207 @@ class TestWaitToFinish(ProviderTestCase):
         eq_(res.status_code, 404)
 
     @test.utils.override_settings(SPA_ENABLE=False)
-    def test_missing_transaction(self):
+    def test_missing_transaction_spa_disabled(self):
         res = self.client.get('{u}?param={t}'.format(u=self.wait_url,
                                                      t=self.trans_id))
         eq_(res.status_code, 403)
+
+
+@test.utils.override_settings(SPA_ENABLE=True, SPA_ENABLE_URLS=True)
+@mock.patch('webpay.bango.views.client.slumber')
+@mock.patch('webpay.bango.views.tasks.payment_notify')
+class TestBangoReturn(BasicSessionCase):
+
+    def setUp(self):
+        super(TestBangoReturn, self).setUp()
+        # Log in.
+        self.session['uuid'] = 'verified-user'
+        # Start a payment.
+        self.trans_uuid = 'solitude-trans-uuid'
+        self.session['trans_id'] = self.trans_uuid
+        self.session['notes'] = {'pay_request': '<request>',
+                                 'issuer_key': '<issuer>'}
+        self.save_session()
+
+    def call(self, overrides=None, expected_status=200,
+             url='spa.complete_payment'):
+        qs = {'MozSignature': 'xyz',
+              'MerchantTransactionId': self.trans_uuid,
+              'BillingConfigurationId': '123',
+              'ResponseCode': 'OK',
+              'Price': '0.99',
+              'Currency': 'EUR',
+              'BangoTransactionId': '456',
+              'Token': '<bango-guid>'}
+        if overrides:
+            qs.update(overrides)
+        res = self.client.get(reverse(url, args=['bango']), qs)
+        eq_(res.status_code, expected_status)
+        return res
+
+    def test_good_return(self, payment_notify, slumber):
+        self.call()
+        payment_notify.delay.assert_called_with(self.trans_uuid)
+
+    def test_invalid_return(self, payment_notify, slumber):
+        err = HttpClientError
+        err.content = ''
+        slumber.bango.notification.post.side_effect = err
+        res = self.call(expected_status=302)
+        redir_url = reverse('spa.payment_failure',
+                            args=['bango', 'NOTICE_ERROR'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+        assert not payment_notify.delay.called
+
+    def test_transaction_not_in_session(self, payment_notify, slumber):
+        del self.session['trans_id']
+        self.save_session()
+
+        self.call(overrides={'MerchantTransactionId': 'invalid-trans'},
+                  expected_status=200)
+        assert slumber.bango.notification.post.called
+
+    def test_transaction_in_session_differs(self, payment_notify, slumber):
+        res = self.call(overrides={'MerchantTransactionId': 'invalid-trans'},
+                        expected_status=302)
+        redir_url = reverse('spa.payment_failure',
+                            args=['bango', 'NO_ACTIVE_TRANS'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+        assert not slumber.bango.notification.post.called
+
+    def test_error(self, payment_notify, slumber):
+        res = self.call(overrides={'ResponseCode': 'NOT OK'},
+                        url='spa.payment_error', expected_status=302)
+        assert slumber.bango.notification.post.called
+        redir_url = reverse('spa.payment_failure',
+                            args=['bango', 'BANGO_ERROR'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_cancel(self, payment_notify, slumber):
+        res = self.call(overrides={'ResponseCode': 'CANCEL'},
+                        url='spa.payment_error',
+                        expected_status=302)
+        redir_url = reverse('spa.payment_failure',
+                            args=['bango', 'USER_CANCELLED'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_not_error(self, payment_notify, slumber):
+        res = self.call(overrides={'ResponseCode': 'OK'},
+                        url='spa.payment_error', expected_status=302)
+        redir_url = reverse('spa.payment_failure',
+                            args=['bango', 'BAD_BANGO_CODE'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_bad_tier(self, payment_notify, slumber):
+        res = self.call(overrides={'ResponseCode': 'NOT_SUPPORTED'},
+                  url='spa.payment_error', expected_status=302)
+        redir_url = reverse('spa.payment_failure',
+                            args=['bango', 'UNSUPPORTED_PAY'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_not_ok(self, payment_notify, slumber):
+        res = self.call(overrides={'ResponseCode': 'NOT_OK'},
+                        url='spa.complete_payment', expected_status=302)
+        redir_url = reverse('spa.payment_failure',
+                            args=['bango', 'BAD_BANGO_CODE'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+
+@test.utils.override_settings(SPA_ENABLE=True, SPA_ENABLE_URLS=True)
+@mock.patch.object(settings, 'PAYMENT_PROVIDER', 'reference')
+class TestProviderSuccess(ProviderTestCase):
+
+    def trust_notice(self):
+        post = self.slumber.provider.reference.notices.post
+        post.return_value = {'result': 'OK'}
+
+    def callback(self, data=None, clear_qs=False, view=None):
+        assert view, 'not sure which view to use'
+        params = {'ext_transaction_id': self.trans_id}
+        if clear_qs:
+            params.clear()
+        if data:
+            params.update(data)
+        return self.client.get(view, params)
+
+    def error(self, **kw):
+        kw['view'] = reverse('spa.payment_error', args=['reference'])
+        return self.callback(**kw)
+
+    def success(self, **kw):
+        kw['view'] = reverse('spa.complete_payment', args=['reference'])
+        return self.callback(**kw)
+
+    def test_missing_ext_trans(self):
+        self.trust_notice()
+        res = self.success(clear_qs=True)
+        redir_url = reverse('spa.payment_failure',
+                            args=['reference', 'TRANS_MISSING'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_missing_session_trans(self):
+        self.trust_notice()
+        del self.session['trans_id']
+        self.save_session()
+        res = self.success()
+        redir_url = reverse('spa.payment_failure',
+                            args=['reference', 'NO_ACTIVE_TRANS'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_success(self):
+        self.trust_notice()
+        res = self.success()
+        eq_(res.status_code, 200)
+        self.payment_notify.delay.assert_called_with(self.trans_id)
+        self.assertTemplateUsed(res, 'spa/index.html')
+
+    def test_error(self):
+        self.trust_notice()
+        res = self.error()
+        assert not self.payment_notify.delay.called, (
+            'did not expect a notification on error')
+        redir_url = reverse('spa.payment_failure',
+                            args=['reference', 'EXT_ERROR'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_invalid_notice_on_success(self):
+        post = self.slumber.provider.reference.notices.post
+        post.return_value = {'result': 'FAIL'}
+
+        res = self.success()
+        redir_url = reverse('spa.payment_failure',
+                            args=['reference', 'NOTICE_ERROR'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_notice_failure(self):
+        post = self.slumber.provider.reference.notices.post
+        post.side_effect = HttpClientError('bad stuff')
+
+        res = self.success()
+        redir_url = reverse('spa.payment_failure',
+                            args=['reference', 'NOTICE_EXCEPTION'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
+
+    def test_invalid_notice_on_error(self):
+        post = self.slumber.provider.reference.notices.post
+        post.return_value = {'result': 'FAIL'}
+        res = self.error()
+        redir_url = reverse('spa.payment_failure',
+                            args=['reference', 'NOTICE_ERROR'])
+        self.assertRedirects(res, redir_url, status_code=302,
+                             target_status_code=400)
 
 
 @test.utils.override_settings(SPA_ENABLE=True, SPA_ENABLE_URLS=True)
@@ -91,3 +291,22 @@ class TestSpaDataAttrs(test.TestCase):
         eq_(doc('body').attr('data-bango-logout-url'),
             settings.PAY_URLS['bango']['base'] +
             settings.PAY_URLS['bango']['logout'])
+
+
+@test.utils.override_settings(SPA_ENABLE=True, SPA_ENABLE_URLS=True)
+class TestView404(test.TestCase):
+
+    def test_404_if_unknown_provider_payment_failure(self):
+        res = self.client.get(reverse('spa.payment_failure',
+                                      args=['whatever', 'NOTICE_EXCEPTION']))
+        eq_(res.status_code, 404)
+
+    def test_404_if_unknown_provider_payment_success(self):
+        res = self.client.get(reverse('spa.complete_payment',
+                                      args=['whatever']))
+        eq_(res.status_code, 404)
+
+    def test_404_if_unknown_provider_payment_error(self):
+        res = self.client.get(reverse('spa.payment_error',
+                                      args=['whatever']))
+        eq_(res.status_code, 404)

--- a/webpay/spa/views.py
+++ b/webpay/spa/views.py
@@ -7,6 +7,10 @@ from django_paranoia.decorators import require_GET
 
 from lib.solitude.api import ProviderHelper
 from webpay.base.logger import getLogger
+from webpay.base import dev_messages as msg
+from webpay.bango.views import _record, RECORDED_OK
+from webpay.pay import tasks
+
 
 log = getLogger('w.spa')
 
@@ -22,17 +26,170 @@ def index(request):
 
 
 @require_GET
-def wait_to_finish(request, provider_name):
-    """After the payment provider finishes the pay flow, wait for completion.
+def payment_failure(request, provider_name, error_code):
+    """Page that serves up a the SPA for a payment failure."""
 
-    The provider redirects here so the UI can poll Solitude until the
-    transaction is complete.
+    if not settings.SPA_ENABLE:
+        return http.HttpResponseForbidden()
+
+    if provider_name not in settings.PAYMENT_PROVIDERS:
+        log.error('Unexpected provider {provider}, query string: {qs}'
+                  .format(provider=provider_name, qs=request.GET))
+        return http.HttpResponseNotFound()
+
+    return render(request, 'spa/index.html', status=400)
+
+
+
+@require_GET
+def payment_error(request, provider_name):
+    """This view is an error view called by the provider
+
+    It should hand off to the relevant error_callback view
+    which will then redirect to payment_failure on the SPA.
+
+    Note: Boku shouldn't call this.
+
+    """
+    if not settings.SPA_ENABLE:
+        return http.HttpResponseForbidden()
+
+    if provider_name in settings.PAYMENT_PROVIDERS:
+        if provider_name == 'bango':
+            return _bango_error(request)
+        elif provider_name == 'reference':
+            return _provider_error(request, provider_name)
+
+    log.error('Unexpected provider {provider}, query string: {qs}'
+              .format(provider=provider_name, qs=request.GET))
+    return http.HttpResponseNotFound()
+
+
+@require_GET
+def _provider_error(request, provider_name):
+    """The standard provider error callback view."""
+    helper = ProviderHelper(provider_name)
+    if helper.name != 'reference':
+        raise NotImplementedError(
+            'only the reference provider is implemented so far')
+
+    try:
+        helper.prepare_notice(request)
+    except msg.DevMessage as m:
+        return http.HttpResponseRedirect(
+            reverse('spa.payment_failure', args=[helper.name, m.code]))
+
+    # TODO: handle user cancellation, bug 957774.
+    log.error('Fatal payment error for {provider}: {code}; query string: {qs}'
+              .format(provider=helper.name,
+                      code=request.GET.get('ResponseCode'),
+                      qs=request.GET))
+    return http.HttpResponseRedirect(
+        reverse('spa.payment_failure', args=[helper.name, msg.EXT_ERROR]))
+
+
+@require_GET
+def _bango_error(request):
+    """The bango error callback view."""
+    log.info('Bango error: %s' % request.GET)
+
+    # We should NOT have OK's coming from Bango, presumably.
+    if request.GET.get('ResponseCode') == 'OK':
+        log.error('in error(): Invalid Bango response code: {code}'
+                  .format(code=request.GET.get('ResponseCode')))
+        return http.HttpResponseRedirect(
+            reverse('spa.payment_failure', args=['bango', msg.BAD_BANGO_CODE]))
+
+    result = _record(request)
+    if result is not RECORDED_OK:
+        return http.HttpResponseRedirect(
+            reverse('spa.payment_failure', args=['bango', result]))
+
+    if request.GET.get('ResponseCode') == 'CANCEL':
+        return http.HttpResponseRedirect(
+            reverse('spa.payment_failure', args=['bango', msg.USER_CANCELLED]))
+
+    if request.GET.get('ResponseCode') == 'NOT_SUPPORTED':
+        # This is a credit card or price point / region mismatch.
+        # In theory users should never trigger this.
+        return http.HttpResponseRedirect(
+            reverse('spa.payment_failure', args=['bango', msg.UNSUPPORTED_PAY]))
+
+    log.error('Fatal Bango error: {code}; query string: {qs}'
+              .format(code=request.GET.get('ResponseCode'), qs=request.GET))
+    return http.HttpResponseRedirect(
+        reverse('spa.payment_failure', args=['bango', msg.BANGO_ERROR]))
+
+
+@require_GET
+def complete_payment(request, provider_name):
+    """After the payment provider flow is finished the provider redirects here
+    for completion.
+
+    This view hands off to the correct completion view if successful serves
+    a completion view from the SPA.
+
+    If it fails it serves an error page in the SPA which allows the user to
+    run `paymentFailed` after displaying an error message.
 
     This view loads up the spa on a specific URL.
 
     """
     if not settings.SPA_ENABLE:
         return http.HttpResponseForbidden()
+
+    if provider_name in settings.PAYMENT_PROVIDERS:
+        if provider_name == 'boku':
+            return _poll_for_completion(request, provider_name)
+        elif provider_name == 'bango':
+            return _complete_bango(request)
+        elif provider_name == 'reference':
+            return _complete_provider(request, provider_name)
+
+    log.error('Unexpected provider {provider}, query string: {qs}'
+              .format(provider=provider_name, qs=request.GET))
+    return http.HttpResponseNotFound()
+
+
+@require_GET
+def _complete_bango(request):
+    """
+    Process a redirect request after the Bango payment has completed.
+    This URL endpoint is pre-arranged with Bango via the Billing Config API.
+
+    Example request:
+
+    ?ResponseCode=OK&ResponseMessage=Success&BangoUserId=1473894939
+    &MerchantTransactionId=webpay%3a14d6a53c-fc4c-4bd1-8dc0-9f24646064b8
+    &BangoTransactionId=1078692145
+    &TransactionMethods=USA_TMOBILE%2cT-Mobile+USA%2cTESTPAY%2cTest+Pay
+    &BillingConfigurationId=218240
+    &MozSignature=
+    c2cf7b937720c6e41f8b6401696cf7aef56975ebe54f8cee51eff4eb317841af
+    &Currency=USD&Network=USA_TMOBILE&Price=0.99&P=
+    """
+    log.info('Bango success: %s' % request.GET)
+
+    # We should only have OK's coming from Bango, presumably.
+    if request.GET.get('ResponseCode') != 'OK':
+        log.error('in success(): Invalid Bango response code: {code}'
+                  .format(code=request.GET.get('ResponseCode')))
+        return http.HttpResponseRedirect(reverse('spa.payment_failure',
+                                         args=['bango', msg.BAD_BANGO_CODE]))
+
+    result = _record(request)
+    if result is not RECORDED_OK:
+        return http.HttpResponseRedirect(reverse('spa.payment_failure',
+                                         args=['bango', result]))
+
+    # Signature verification was successful; fulfill the payment.
+    tasks.payment_notify.delay(request.GET.get('MerchantTransactionId'))
+    return render(request, 'spa/index.html')
+
+
+@require_GET
+def _poll_for_completion(request, provider_name):
+    """This view polls for a transaction."""
 
     helper = ProviderHelper(provider_name)
     trans_uuid = helper.provider.transaction_from_notice(request.GET)
@@ -45,6 +202,25 @@ def wait_to_finish(request, provider_name):
 
     trans_url = reverse('provider.transaction_status', args=[trans_uuid])
 
-    # For the SPA we are serving up the app on the wait-to-finish url.
+    # For the SPA we are serving up the app on the complete-payment url.
     return render(request, 'spa/index.html',
                   {'transaction_status_url': trans_url})
+
+
+@require_GET
+def _complete_provider(request, provider_name):
+    """The standard provider success callback view."""
+
+    helper = ProviderHelper(provider_name)
+    if helper.name != 'reference':
+        raise NotImplementedError(
+            'only the reference provider is implemented so far')
+
+    try:
+        transaction_id = helper.prepare_notice(request)
+    except msg.DevMessage as m:
+        return http.HttpResponseRedirect(reverse('spa.payment_failure',
+                                         args=[helper.name, m.code]))
+
+    tasks.payment_notify.delay(transaction_id)
+    return render(request, 'spa/index.html')

--- a/webpay/urls.py
+++ b/webpay/urls.py
@@ -1,8 +1,6 @@
 from django.conf import settings
 from django.conf.urls.defaults import patterns, include, url
 
-from webpay.spa.views import index as spa_index
-from webpay.spa.views import wait_to_finish as spa_wait_to_finish
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
@@ -22,9 +20,23 @@ urlpatterns = patterns('',
 )
 
 if settings.SPA_ENABLE_URLS:
+
+    from webpay.spa.views import index as spa_index
+    from webpay.spa.views import complete_payment
+    from webpay.spa.views import payment_error
+    from webpay.spa.views import payment_failure
+
     urlpatterns += patterns('',
-        url(r'^mozpay/spa/(?P<provider_name>[^/]+)/wait-to-finish',
-            spa_wait_to_finish, name='spa.wait_to_finish'),
+        # The callback url for payment completion/success. Called by providers.
+        url(r'^mozpay/spa/provider/(?P<provider_name>[a-z][^/]+)/complete-payment$',
+            complete_payment, name='spa.complete_payment'),
+        # The callback url for payment errors. Called by providers.
+        url(r'^mozpay/spa/provider/(?P<provider_name>[a-z][^/]+)/payment-error$',
+            payment_error, name='spa.payment_error'),
+        # A generic payment failure view.
+        url(r'^mozpay/spa/provider/(?P<provider_name>[a-z][^/]+)/payment-failure/(?P<error_code>[A-Z_]+)$',
+            payment_failure, name='spa.payment_failure'),
+        # All the other SPA urls.
         url(r'^mozpay/spa/(?:' + '|'.join(settings.SPA_URLS) + ')$',
             spa_index, name='spa.index'),
         url(r'^mozpay/v1/api/', include('webpay.api.urls', namespace='api'))


### PR DESCRIPTION
UPDATED (7th July)
- Move to using same page in the SPA for success in Bango + Reference provider (as well as Boku).
- Redirect from SPA provider error views to a 'payment_failure' view in SPA which will display the correct error message based on the error messages lookup.
- Add the  view to serve the SPA for error pages called by the provider and the payment failure page.

Note: All the provider views and tests are copies of the pre-existing views + tests with modifications to suit this usage.
