### PR TITLE
    Add buyer_uuid to payment_notify (bug 1034253)

### DIFF
--- a/webpay/bango/tests/test_views.py
+++ b/webpay/bango/tests/test_views.py
@@ -4,7 +4,6 @@ import urllib
 from django.core.urlresolvers import reverse
 
 import mock
-from mock import ANY
 from nose.tools import eq_
 from slumber.exceptions import HttpClientError
 from test_utils import TestCase
@@ -19,7 +18,8 @@ class TestBangoReturn(BasicSessionCase):
     def setUp(self):
         super(TestBangoReturn, self).setUp()
         # Log in.
-        self.session['uuid'] = 'verified-user'
+        self.buyer_uuid = 'verified-user'
+        self.session['uuid'] = self.buyer_uuid
         # Start a payment.
         self.trans_uuid = 'solitude-trans-uuid'
         self.session['trans_id'] = self.trans_uuid
@@ -45,7 +45,8 @@ class TestBangoReturn(BasicSessionCase):
 
     def test_good_return(self, payment_notify, slumber):
         self.call()
-        payment_notify.delay.assert_called_with(self.trans_uuid)
+        payment_notify.delay.assert_called_with(self.trans_uuid,
+                                                self.buyer_uuid)
 
     def test_invalid_return(self, payment_notify, slumber):
         err = HttpClientError

--- a/webpay/bango/views.py
+++ b/webpay/bango/views.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import render
@@ -97,7 +95,8 @@ def success(request):
         return system_error(request, code=result)
 
     # Signature verification was successful; fulfill the payment.
-    tasks.payment_notify.delay(request.GET.get('MerchantTransactionId'))
+    tasks.payment_notify.delay(request.GET.get('MerchantTransactionId'),
+                               request.session['uuid'])
     return render(request, 'bango/success.html')
 
 

--- a/webpay/pay/tests/test_views.py
+++ b/webpay/pay/tests/test_views.py
@@ -546,6 +546,9 @@ class TestPostback(Base):
 
     def setUp(self):
         super(TestPostback, self).setUp()
+        self.session['uuid'] = '<user_uuid>'
+        self.save_session()
+
         self.callback_success = reverse('pay.callback_success_url')
         self.callback_error = reverse('pay.callback_error_url')
 

--- a/webpay/pay/views.py
+++ b/webpay/pay/views.py
@@ -408,7 +408,8 @@ def _callback_url(request, is_success):
         if 'ext_transaction_id' in querystring:
             ext_transaction_id = querystring['ext_transaction_id']
             if is_success:
-                tasks.payment_notify.delay(ext_transaction_id)
+                buyer_uuid = request.session['uuid']
+                tasks.payment_notify.delay(ext_transaction_id, buyer_uuid)
             else:
                 tasks.chargeback_notify.delay(ext_transaction_id)
             return http.HttpResponse(status=204)

--- a/webpay/provider/views.py
+++ b/webpay/provider/views.py
@@ -78,7 +78,7 @@ def success(request, provider_name):
     except msg.DevMessage as m:
         return system_error(request, code=m.code)
 
-    tasks.payment_notify.delay(transaction_id)
+    tasks.payment_notify.delay(transaction_id, request.session['uuid'])
     return render(request, 'provider/success.html')
 
 
@@ -119,6 +119,6 @@ def notification(request, provider_name):
     log.info('Processing notification for transaction {t}; status={s}'
              .format(t=transaction_uuid, s=trans['status']))
     if trans['status'] == STATUS_COMPLETED:
-        tasks.payment_notify.delay(transaction_uuid)
+        tasks.payment_notify.delay(transaction_uuid, request.session['uuid'])
 
     return HttpResponse('OK')


### PR DESCRIPTION
- Add buyer_uuid to payment_notify task
- Send buyer_uuid from request session to task
- Update tests
