### PR TITLE
Remove redundant SPA wait-to-finish

### DIFF
--- a/webpay/spa/views.py
+++ b/webpay/spa/views.py
@@ -19,32 +19,3 @@ def index(request, view_name=None):
         return http.HttpResponseForbidden()
 
     return render(request, 'spa/index.html')
-
-
-@require_GET
-def wait_to_finish(request, provider_name):
-    """After the payment provider finishes the pay flow, wait for completion.
-
-    The provider redirects here so the UI can poll Solitude until the
-    transaction is complete.
-
-    This view loads up the spa on a specific URL.
-
-    """
-    if not settings.SPA_ENABLE:
-        return http.HttpResponseForbidden()
-
-    helper = ProviderHelper(provider_name)
-    trans_uuid = helper.provider.transaction_from_notice(request.GET)
-    if not trans_uuid:
-        # This could happen if someone is tampering with the URL or if
-        # the payment provider changed their URL parameters.
-        log.info('no transaction found for provider {p}; url: {u}'
-                 .format(p=helper.provider.name, u=request.get_full_path()))
-        return http.HttpResponseNotFound()
-
-    trans_url = reverse('provider.transaction_status', args=[trans_uuid])
-
-    # For the SPA we are serving up the app on the wait-to-finish url.
-    return render(request, 'spa/index.html',
-                  {'transaction_status_url': trans_url})


### PR DESCRIPTION
We don't need this view any more as we're now using the pre-existing view [1] so this copy can be removed.

[1] https://github.com/mozilla/webpay/blob/master/webpay/provider/views.py#L23
