### PR TITLE
    Create Buyer at Persona login (bug #1040925)

### DIFF
--- a/webpay/api/api.py
+++ b/webpay/api/api.py
@@ -51,18 +51,11 @@ class PinViewSet(viewsets.ViewSet):
     def create(self, request):
         form = CreatePinForm(uuid=request.session['uuid'], data=request.DATA)
         if form.is_valid():
-            if getattr(form, 'buyer_exists', None):
-                res = client.change_pin(form.uuid,
-                                        form.cleaned_data['pin'],
-                                        etag=form.buyer_etag,
-                                        pin_confirmed=True,
-                                        clear_was_locked=True)
-            else:
-                res = client.create_buyer(form.uuid,
-                                          pin=form.cleaned_data['pin'],
-                                          pin_confirmed=True,
-                                          email=request.session[
-                                              'logged_in_user'])
+            res = client.change_pin(form.uuid,
+                                    form.cleaned_data['pin'],
+                                    etag=form.buyer_etag,
+                                    pin_confirmed=True,
+                                    clear_was_locked=True)
 
             if form.handle_client_errors(res):
                 set_user_has_pin(request, True)

--- a/webpay/api/tests/test_api.py
+++ b/webpay/api/tests/test_api.py
@@ -136,15 +136,6 @@ class TestPost(PIN):
         res = self.client.post(self.url, {})
         eq_(res.status_code, 400)
 
-    def test_no_user(self):
-        self.solitude.generic.buyer.get_object_or_404.side_effect = (
-            ObjectDoesNotExist)
-        res = self.client.post(self.url, {'pin': '1234'})
-        self.solitude.generic.buyer.post.assert_called_with(
-            {'uuid': self.uuid, 'pin': '1234',
-             'pin_confirmed': True, 'email': self.email})
-        eq_(res.status_code, 204)
-
     @mock.patch('webpay.api.api.client')
     def test_user(self, solitude_client):
         self.solitude.generic.buyer.get_object_or_404.return_value = {

--- a/webpay/auth/tests/test_decorators.py
+++ b/webpay/auth/tests/test_decorators.py
@@ -43,6 +43,9 @@ class TestBuyerHasPin(Base):
     def test_no_user(self, slumber):
         slumber.generic.buyer.get_object_or_404.side_effect = (
             ObjectDoesNotExist)
+        slumber.generic.buyer.post.return_value = {
+            'uuid': 'new-user',
+        }
         data = self.do_auth()
         eq_(self.client.session.get('uuid_has_pin'), False)
         eq_(data['needs_redirect'], True)
@@ -95,6 +98,9 @@ class TestBuyerHasResetFlag(Base):
     def test_no_user(self, slumber):
         slumber.generic.buyer.get_object_or_404.side_effect = (
             ObjectDoesNotExist)
+        slumber.generic.buyer.post.return_value = {
+            'uuid': 'new-user',
+        }
         self.do_auth()
         eq_(self.client.session.get('uuid_needs_pin_reset'), False)
 

--- a/webpay/auth/tests/test_utils_.py
+++ b/webpay/auth/tests/test_utils_.py
@@ -34,6 +34,17 @@ class TestUUID(test.TestCase):
         assert req.session.__setitem__.called
 
     @mock.patch('webpay.auth.utils.client')
+    def test_set_user_create_buyer(self, client):
+        email = 'f@f.com'
+        req = mock.MagicMock()
+        user = get_uuid(email)
+        client.get_buyer.return_value = {}
+        eq_(set_user(req, email), user)
+        assert client.get_buyer.called
+        assert client.create_buyer.called
+        assert req.session.__setitem__.called
+
+    @mock.patch('webpay.auth.utils.client')
     def test_update_user_pin_unlock(self, client):
         email = 'f@f.com'
         req = http.HttpRequest()

--- a/webpay/auth/utils.py
+++ b/webpay/auth/utils.py
@@ -63,11 +63,16 @@ def set_user(request, email):
     request.session['uuid'] = uuid
     # This is only used by navigator.id.watch()
     request.session['logged_in_user'] = email
-    return update_session(request, uuid, new_uuid, email)
 
-
-def update_session(request, uuid, new_uuid, email):
     buyer = client.get_buyer(uuid)
+    if not buyer:
+        buyer = client.create_buyer(uuid, email)
+
+    return update_session(request, uuid, new_uuid, email, buyer=buyer)
+
+
+def update_session(request, uuid, new_uuid, email, buyer=None):
+    buyer = buyer or client.get_buyer(uuid)
 
     # Some buyers may not have email set
     # We must update them to store their email

--- a/webpay/pin/forms.py
+++ b/webpay/pin/forms.py
@@ -79,7 +79,6 @@ class CreatePinForm(BasePinForm):
         pin = self.cleaned_data['pin']
         buyer = client.get_buyer(self.uuid)
         if buyer and self.handle_client_errors(buyer):
-            self.buyer_exists = True
             try:
                 self.buyer_etag = buyer['etag']
             except KeyError:

--- a/webpay/pin/tests/test_forms.py
+++ b/webpay/pin/tests/test_forms.py
@@ -30,23 +30,15 @@ class PinFormOutputTest(BasePinFormTestCase):
 
 class CreatePinFormTest(BasePinFormTestCase):
 
-    @patch.object(client, 'get_buyer', lambda x: {})
-    def test_new_user(self):
-        form = forms.CreatePinForm(uuid=self.uuid, data=self.data)
-        assert form.is_valid(), form.errors
-        assert not getattr(form, 'buyer_exists', False)
-
     @patch.object(client, 'get_buyer', lambda x: {'uuid': x})
     def test_existing_buyer(self):
         form = forms.CreatePinForm(uuid=self.uuid, data=self.data)
         assert form.is_valid(), form.errors
-        assert getattr(form, 'buyer_exists', False)
 
     @patch.object(client, 'get_buyer', lambda x: {'uuid:': x, 'pin': 'fake'})
     def test_has_pin(self):
         form = forms.CreatePinForm(uuid=self.uuid, data=self.data)
         assert not form.is_valid()
-        assert getattr(form, 'buyer_exists', False)
         assert 'You have already created a PIN.' in str(form.errors)
         eq_(len(form.pin_error_codes), 1)
         eq_(form.pin_error_codes, ['PIN_ALREADY_CREATED'])

--- a/webpay/pin/tests/test_views.py
+++ b/webpay/pin/tests/test_views.py
@@ -32,19 +32,6 @@ class CreatePinViewTest(PinViewTestCase):
 
     @patch('lib.solitude.api.client.create_buyer', auto_spec=True)
     @patch('lib.solitude.api.client.change_pin', auto_spec=True)
-    @patch('webpay.pin.views.set_user_has_pin', auto_spec=True)
-    @patch.object(client, 'get_buyer', lambda x: {})
-    def test_buyer_does_not_exist(self, set_user_has_pin, change_pin,
-                                  create_buyer):
-        pin = '1234'
-        res = self.client.post(self.url, data={'pin': pin})
-        create_buyer.assert_called_with(self.uuid, email=self.email, pin=pin)
-        assert not change_pin.called
-        set_user_has_pin.assert_called_with(ANY, True)
-        assert res['Location'].endswith(reverse('pin.confirm'))
-
-    @patch('lib.solitude.api.client.create_buyer', auto_spec=True)
-    @patch('lib.solitude.api.client.change_pin', auto_spec=True)
     @patch.object(client, 'get_buyer', lambda x: {'uuid': 'some:uuid'})
     def test_buyer_does_exist_with_no_pin(self, change_pin, create_buyer):
         res = self.client.post(self.url, data={'pin': '1234'})

--- a/webpay/pin/views.py
+++ b/webpay/pin/views.py
@@ -29,18 +29,13 @@ def create(request):
     if request.method == 'POST':
         form = forms.CreatePinForm(uuid=get_user(request), data=request.POST)
         if form.is_valid():
-            if getattr(form, 'buyer_exists', False):
-                try:
-                    res = client.change_pin(form.uuid,
-                                            pin=form.cleaned_data['pin'],
-                                            etag=form.buyer_etag)
-                except ResourceModified:
-                    return system_error(request, code=msg.RESOURCE_MODIFIED)
-            else:
-                res = client.create_buyer(form.uuid,
-                                          pin=form.cleaned_data['pin'],
-                                          email=request.session[
-                                              'logged_in_user'])
+            try:
+                res = client.change_pin(form.uuid,
+                                        pin=form.cleaned_data['pin'],
+                                        etag=form.buyer_etag)
+            except ResourceModified:
+                return system_error(request, code=msg.RESOURCE_MODIFIED)
+
             if form.handle_client_errors(res):
                 set_user_has_pin(request, True)
                 return http.HttpResponseRedirect(reverse('pin.confirm'))


### PR DESCRIPTION
- Check and create buyer when Persona login takes place
- Remove create buyer from PIN creation time in API/Views
- Update tests
