### PR TITLE
Fix initial progress bar

### DIFF
--- a/webpay/spa/templates/spa/index.html
+++ b/webpay/spa/templates/spa/index.html
@@ -41,7 +41,7 @@
       <div id="progress" class="progress">
         <div class="throbber">
           <div class="inner">
-            <progress></progress>
+            <div class="progress"></div>
             <p class="msg">{{ gettext('Loading...')}}</p>
           </div>
         </div>


### PR DESCRIPTION
The progress indicator has changed. This updates webpay so it will pick up the right styles when serving the SPA.
