### PR TITLE
add in a default user

### DIFF
--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -411,7 +411,13 @@ JS_SETTINGS = {
 MARKETPLACE_URL = host
 
 # The OAuth config from the marketplace.
-MARKETPLACE_OAUTH = {'key': '', 'secret': ''}
+#
+# These are the default ones set in the initdata in zamboni. They are
+# overridden on every server.
+MARKETPLACE_OAUTH = {
+    'key': 'mkt:default:1:amckay+docker-api@mozilla.com',
+    'secret': 'some-secret-eh?'
+}
 
 # Configure our test runner for some nice test output.
 NOSE_PLUGINS = [


### PR DESCRIPTION
This is going outside of the scope of 1028952, but the problem is similar. Out of the box the APIs on all these services cannot speak to each other. This sets the default API values in webpay out of the box to match zamboni out of the box. 
