### PR TITLE
data-mkt-user can be true/false/falsey (bug 1107700)

### DIFF
--- a/webpay/spa/templates/spa/index.html
+++ b/webpay/spa/templates/spa/index.html
@@ -10,7 +10,7 @@
   </head>
   <body class="spartacus"
     data-logged-in-user="{{ session.get('logged_in_user', '') }}"
-    data-mkt-user="{% if mkt_user %}true{% else %}false{% endif %}"
+    data-mkt-user="{% if mkt_user %}true{% elif mkt_user == False %}false{% endif %}"
     data-privacy-policy="https://marketplace.firefox.com/privacy-policy"
     data-reset-user-url="{{ url('auth.reset_user') }}"
     data-static-url="{{ settings.SPARTACUS_STATIC }}"

--- a/webpay/spa/tests/test_views.py
+++ b/webpay/spa/tests/test_views.py
@@ -20,6 +20,9 @@ class TestSpaViews(test.TestCase):
     def test_enter_pin(self):
         res = self.client.get(reverse('spa:index', args=['enter-pin']))
         eq_(res.status_code, 200)
+        doc = pq(res.content)
+        # data-mkt-user should be falsey.
+        eq_(doc('body').attr('data-mkt-user'), '')
         self.assertTemplateUsed(res, 'spa/index.html')
 
     def test_reversal(self):

--- a/webpay/spa/views.py
+++ b/webpay/spa/views.py
@@ -12,13 +12,17 @@ log = getLogger('w.spa')
 
 
 @require_GET
-def index(request, view_name=None):
+def index(request, view_name=None, start_view=None):
     """Page that serves the static Single Page App (Spartacus)."""
     if not settings.SPA_ENABLE:
         return http.HttpResponseForbidden()
-    ctx = {'mkt_user': False}
+    ctx = {}
     ctx['fxa_state'], ctx['fxa_auth_url'] = fxa_auth_info(request)
     jwt = request.GET.get('req')
+
+    if jwt:
+        ctx['mkt_user'] = False
+
     # If this is a Marketplace-issued JWT, verify its signature and skip login
     # for the purchaser named in it.
     if jwt and _get_issuer(jwt) == settings.KEY:


### PR DESCRIPTION
We're only going to show the logout interstitial at the start of the payment flow (e.g. there's a jwt) and we know that the user didn't come from marketplace.

This defaults the `data-mkt-user` to an empty string (which essentially means we don't know whether the user came from marketplace or not.)

If there's a jwt and no email  then we know the user definitely didn't come from marketplace so the value is `'false'`. 

When the jwt is present and has the email the value is `'true'`

This way it feels like the data-mkt-user value is more correct rather than only being `'true'` or `'false'`. Previously as we defaulted to false this could be false when the user comes to a different view despite actually having originated the flow from the marketplace.

This needs a follow-up patch in spartacus to test the handling of the possibly values.
