### PR TITLE
Use SPA for bango cancellations too (bug 1124676)

### DIFF
--- a/webpay/bango/tests/test_views.py
+++ b/webpay/bango/tests/test_views.py
@@ -76,12 +76,6 @@ class TestBangoReturn(BasicSessionCase):
         assert slumber.bango.notification.post.called
         self.assertTemplateUsed(res, 'error.html')
 
-    def test_cancel(self, payment_notify, slumber):
-        res = self.call(overrides={'ResponseCode': 'CANCEL'},
-                        url='bango.error',
-                        expected_status=200)
-        self.assertTemplateUsed(res, 'bango/cancel.html')
-
     def test_not_error(self, payment_notify, slumber):
         self.call(overrides={'ResponseCode': 'OK'}, url='bango.error',
                   expected_status=400)
@@ -99,6 +93,15 @@ class TestBangoReturn(BasicSessionCase):
         res = self.call()
         doc = pq(res.content)
         eq_(doc('body').attr('data-start-view'), 'payment-success')
+        self.assertTemplateUsed('spa/index.html')
+
+    @mock.patch.object(settings, 'SPA_ENABLE', True)
+    def test_cancel_spa(self, payment_notify, slumber):
+        res = self.call(overrides={'ResponseCode': 'CANCEL'},
+                        url='bango.error',
+                        expected_status=400)
+        doc = pq(res.content)
+        eq_(doc('body').attr('data-start-view'), 'payment-failed')
         self.assertTemplateUsed('spa/index.html')
 
     @mock.patch.object(settings, 'SPA_ENABLE', True)

--- a/webpay/bango/views.py
+++ b/webpay/bango/views.py
@@ -125,8 +125,7 @@ def error(request):
         return system_error(request, code=result)
 
     if request.GET.get('ResponseCode') == 'CANCEL':
-        return render(request, 'bango/cancel.html',
-                      {'error_code': msg.USER_CANCELLED})
+        return system_error(request, code=msg.USER_CANCELLED)
 
     if request.GET.get('ResponseCode') == 'NOT_SUPPORTED':
         # This is a credit card or price point / region mismatch.


### PR DESCRIPTION
r? kumar

`system_error` will use the spa template when enabled. 

Does a 400 seem reasonable?