### PR TITLE
Handle NULL defaultLocale (bug 1132488)

### DIFF
--- a/webpay/pay/forms.py
+++ b/webpay/pay/forms.py
@@ -92,7 +92,8 @@ class VerifyForm(ParanoidForm):
             raise forms.ValidationError(msg.BAD_ICON_KEY)
 
         for fn in msg.SHORT_FIELDS:
-            if (len(payload['request'].get(fn, '')) >
+            # These fields might be NULL so make sure they are strings:
+            if (len(payload['request'].get(fn, None) or '') >
                     settings.SHORT_FIELD_MAX_LENGTH):
                 raise forms.ValidationError(msg.SHORT_FIELD_TOO_LONG_CODE[fn])
 

--- a/webpay/pay/tests/test_forms.py
+++ b/webpay/pay/tests/test_forms.py
@@ -141,6 +141,16 @@ class TestVerifyForm(Base):
         eq_(form.key, settings.KEY)
         eq_(form.secret, settings.SECRET)
 
+    def test_empty_locales_and_null_default(self):
+        payload = self.payload(extra_req={
+            'locales': {},
+            'defaultLocale': None,
+        })
+        req = self.request(iss=self.key, app_secret=self.secret,
+                           payload=payload)
+        form = VerifyForm({'req': req})
+        assert form.is_valid()
+
     def test_locales_and_without_defaultLocale(self):
         payload = self.payload(extra_req={
             'locales': {


### PR DESCRIPTION
This traceback was introduced by in-app JWTs
in bug 1131708