### PR TITLE
Bypass reauth for missing timestamps (bug 1141514)

### DIFF
--- a/webpay/pin/forms.py
+++ b/webpay/pin/forms.py
@@ -139,6 +139,7 @@ class ResetPinForm(BasePinForm):
         Check that the user re-authenticated with Firefox Accounts
         sometime after they requested the PIN reset.
         """
+
         reauth_ok = False
         log.info('PIN reset: user_reset from session: {reset}'
                  .format(reset=self.user_reset))
@@ -156,6 +157,9 @@ class ResetPinForm(BasePinForm):
         elif not fxa_auth_ts:
             log.warning(
                 'PIN reset error: user_reset[fxa_auth_ts] not in session')
+            if not settings.REQUIRE_REAUTH_TS_FOR_PIN_RESET:
+                log.warning('missing fxa_auth_ts ignored for PIN reset')
+                reauth_ok = True
         elif fxa_auth_ts < start_ts:
             log.warning(
                 'PIN reset error: fxa_auth_ts {f} occurred before reset {r}'

--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -590,6 +590,15 @@ FXA_CLIENT_SECRET = (
 # before we get this far.
 FXA_PIN_REAUTH_EXPIRY = 60 * 10
 
+# If True, require the Firefox Accounts server(s) to provide us
+# with a timestamp of the last time the user re-entered their password
+# before allowing a PIN reset. This prevents client side tampering
+# to reset a PIN without knowing the user's Firefox Account password.
+# When False, a server provided timestamp will still be honored if it
+# exists. This means the oauth flow is still secure when this setting
+# is False. See bug 1141514.
+REQUIRE_REAUTH_TS_FOR_PIN_RESET = False
+
 # Set of email addresses for users that gain super powers once authenticated.
 # For example, they will see an admin screen to simulate certain things.
 USERS_WITH_SUPER_POWERS = []


### PR DESCRIPTION
The FxA oauth flow exposes a valid timestamp but
this was never implemented for native (mozId).
This setting allows PIN resets to proceed from the native
mozId flow.