### PR TITLE
Upgrade to mainline PyJWT (part of bug 1145024)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -29,7 +29,7 @@ m2secret==0.1.1
 mobile-codes==0.2.1
 mock==1.0b1
 mozilla-logger==0.1
-mozpay==2.0.0
+mozpay==2.1.0
 newrelic==2.4.0.4
 # Nose has to be here because django-nose is in installed apps.
 nose==1.2.1
@@ -37,7 +37,7 @@ nosenicedots==0.5
 nose-blockage==0.1.2
 oauth2==1.5.211
 oauthlib==0.6.2
-PyJWT-mozilla==0.1.4.2
+PyJWT==1.0.1
 python-dateutil==2.1
 python-memcached==1.48
 pytz==2010e

--- a/webpay/api/tests/test_api.py
+++ b/webpay/api/tests/test_api.py
@@ -134,10 +134,10 @@ class TestPay(Base, BaseAPICase):
         eq_(res.status_code, 400)
 
     def test_unsupported_jwt_algorithm(self):
-        with self.settings(SUPPORTED_JWT_ALGORITHMS=['HS256']):
+        with self.settings(SUPPORTED_JWT_ALGORITHMS=['HS384']):
             res = self.post(
-                request_kwargs={'jwt_kwargs': {'algorithm': 'none'}})
-        eq_(json.loads(res.content)['error_code'], 'INVALID_JWT_OBJ',
+                request_kwargs={'jwt_kwargs': {'algorithm': 'HS256'}})
+        eq_(json.loads(res.content)['error_code'], 'INVALID_JWT',
             res.content)
         eq_(res.status_code, 400)
 

--- a/webpay/pay/forms.py
+++ b/webpay/pay/forms.py
@@ -1,5 +1,3 @@
-import json
-
 from django import forms
 from django.conf import settings
 
@@ -46,7 +44,7 @@ class VerifyForm(ParanoidForm):
         log.debug('incoming JWT data: %r' % jwt_data)
         try:
             payload = jwt.decode(jwt_data, verify=False)
-        except jwt.DecodeError, exc:
+        except jwt.InvalidTokenError, exc:
             log.debug('Error decoding JWT: {0}'.format(exc))
             raise forms.ValidationError(msg.JWT_DECODE_ERR)
         log.debug('Received JWT: %r' % payload)
@@ -56,15 +54,6 @@ class VerifyForm(ParanoidForm):
             # error. If it becomes a headache for developers we can make a
             # guess and check the string for a JSON object.
             log.info('JWT was not a dict, it was %r' % type(payload))
-            raise forms.ValidationError(msg.INVALID_JWT_OBJ)
-
-        # The decode method already parses the header like this
-        # but does not give us access to it so we need to re-parse it.
-        header = json.loads(jwt.base64url_decode(jwt_data.split('.')[0]))
-        if header['alg'] not in settings.SUPPORTED_JWT_ALGORITHMS:
-            log.debug(
-                'JWT header alg is {alg} which is not supported. JWT: {jwt}'
-                .format(alg=header['alg'], jwt=jwt_data))
             raise forms.ValidationError(msg.INVALID_JWT_OBJ)
 
         try:

--- a/webpay/pay/tasks.py
+++ b/webpay/pay/tasks.py
@@ -453,6 +453,8 @@ def _notify(notifier_task, trans, extra_response=None, simulated=NOT_SIMULATED,
                          'currency': trans['currency']}
     issued_at = gmtime()
     notice = {'iss': settings.NOTIFY_ISSUER,
+              # The original issuer of the request will now become the
+              # audience of the notice.
               'aud': notes['issuer_key'],
               'typ': typ,
               'iat': issued_at,

--- a/webpay/pay/tests/__init__.py
+++ b/webpay/pay/tests/__init__.py
@@ -30,6 +30,7 @@ class Base(BasicSessionCase, JWTtester):
     def request(self, **kw):
         # This simulates payment requests which do not have response.
         kw.setdefault('include_response', False)
+        # By default, Marketplace will issue payment requests.
         kw.setdefault('iss', settings.KEY)
         kw.setdefault('app_secret', settings.SECRET)
         return super(Base, self).request(**kw)

--- a/webpay/pay/tests/test_forms.py
+++ b/webpay/pay/tests/test_forms.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
-
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -123,16 +121,6 @@ class TestVerifyForm(Base):
             # This means we've successfully looked up the InappConfig.
             eq_(form.key, self.key)
             eq_(form.secret, self.secret)
-
-    def test_double_encoded_jwt(self):
-        payload = self.payload()
-        # Some jwt libraries are doing this, I think.
-        payload = json.dumps(payload)
-        req = self.request(iss=self.key, app_secret=self.secret,
-                           payload=payload)
-        with self.settings(INAPP_KEY_PATHS={None: sample}, DEBUG=True):
-            form = VerifyForm({'req': req})
-            assert not form.is_valid()
 
     def test_valid_purchase(self):
         payload = self.request(iss=settings.KEY, app_secret=settings.SECRET)

--- a/webpay/spa/views.py
+++ b/webpay/spa/views.py
@@ -27,10 +27,12 @@ def index(request, view_name=None, start_view=None):
     # for the purchaser named in it.
     if jwt and _get_issuer(jwt) == settings.KEY:
         try:
-            data = verify_sig(jwt, settings.SECRET)
+            data = verify_sig(jwt, settings.SECRET,
+                              expected_aud=settings.DOMAIN)
             data = data['request'].get('productData', '')
-        except InvalidJWT:
-            pass
+        except InvalidJWT, exc:
+            log.debug('ignoring invalid Marketplace JWT error: {e}'
+                      .format(e=exc))
         else:
             product_data = urlparse.parse_qs(data)
             emails = product_data.get('buyer_email')


### PR DESCRIPTION
This switches us from PyJWT-mozilla to PyJWT which
is more maintained and has more features now.
This doesn't introduce any new functionality but
to use the new PyJWT we also needed a mozpay-py upgrade.