### PR TITLE
Do not propagate exceptions (maybe bug 1132548)

### DIFF
--- a/webpay/settings/base.py
+++ b/webpay/settings/base.py
@@ -25,7 +25,9 @@ DATABASES = {
 }
 
 DEBUG = True
-DEBUG_PROPAGATE_EXCEPTIONS = True
+# If set to True, you can see tracebacks in the console
+# for local development.
+DEBUG_PROPAGATE_EXCEPTIONS = False
 
 # Tell Django to do everything in UTC.
 USE_TZ = True


### PR DESCRIPTION
The docs suggest to never propagate exceptions
on a live site and TBH I'm not sure why this was
here to begin with.