### PR TITLE
Handle None type locale descriptions (bug 1193739)

### DIFF
--- a/webpay/pay/tests/test_api.py
+++ b/webpay/pay/tests/test_api.py
@@ -132,6 +132,17 @@ class TestPay(PayTester):
         req = self.client.session['notes']['pay_request']['request']
         eq_(len(req['locales']['it']['description']), 255)
 
+    def test_handle_none_type_locale_description(self):
+        payjwt = self.payload()
+        payjwt['request']['defaultLocale'] = 'en'
+        payjwt['request']['locales'] = {
+            'it': {
+                'description': None
+            }
+        }
+        res = self.post(req=self.request(payload=payjwt))
+        eq_(res.status_code, 200)
+
     @mock.patch.object(settings, 'PRODUCT_DESCRIPTION_LENGTH', 255)
     def test_truncate_long_description(self):
         payjwt = self.payload()

--- a/webpay/pay/views.py
+++ b/webpay/pay/views.py
@@ -183,7 +183,7 @@ def _trim_pay_request(req):
     if req['request'].get('locales'):
         for slug, locale in req['request']['locales'].items():
             if 'description' in locale:
-                desc = _trim(locale['description'])
+                desc = _trim(locale['description'] or '')
                 req['request']['locales'][slug]['description'] = desc
 
 


### PR DESCRIPTION
Traceback:
http://sentry.mktmon.services.phx1.mozilla.com/mkt/webpay-prod/group/19858/