### PR TITLE
Fix session to retry failed trans. (bug 1213978)

### DIFF
--- a/webpay/pay/tasks.py
+++ b/webpay/pay/tasks.py
@@ -83,9 +83,6 @@ def configure_transaction(request, trans=None, mcc=None, mnc=None):
                  % (request.session['trans_id'], trans.get('status')))
         return (False, None)
 
-    # Prevent configuration from running twice.
-    request.session['configured_trans'] = request.session['trans_id']
-
     # Localize the product before sending it off to solitude/bango.
     _localize_pay_request(request)
 
@@ -104,6 +101,10 @@ def configure_transaction(request, trans=None, mcc=None, mnc=None):
                     request.session['notes'],
                     request.session['uuid'],
                     [p.name for p in providers])
+
+    # Now that the background task has been started successfully,
+    # prevent configuration from running twice.
+    request.session['configured_trans'] = request.session['trans_id']
 
     return (True, None)
 

--- a/webpay/pay/tests/test_tasks.py
+++ b/webpay/pay/tests/test_tasks.py
@@ -954,6 +954,17 @@ class TestConfigureTransaction(BaseStartPay):
         eq_(configured, False)  # Second call should do nothing.
         eq_(self.start_pay.call_count, 1)
 
+    def test_always_reconfigure_transaction_after_error(self):
+        self.start_pay.side_effect = RuntimeError('cannot connect to celery')
+        session = {}
+        for tries in range(2):
+            try:
+                self.start(session=session)
+            except RuntimeError:
+                pass
+        # Make sure the second call retries configuration:
+        eq_(self.start_pay.call_count, 2)
+
     def test_no_trans_id(self):
         request = RequestFactory().get('/')
         request.session = {}


### PR DESCRIPTION
In case we lose the connection to RabbitMQ/celery (which will raise an exception), we don't want to store the 'already configured' flag in the session.
I'm not 100% sure that sessions are preserved in 500 errors but maybe they are.
If so, this would fix an issue I see where stale transaction IDs are hanging around in people's sessions even after the RabbitMQ issues have been resolved.